### PR TITLE
Bump vulnerable dev deps (take 2)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
       - run:
           name: List deps
           command: |
-            npm list
+            npm list || true
             pdftops -v
       - save_cache:
           key: v2-npm-{{ checksum "package-lock.json" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,9 +44,9 @@ jobs:
           paths:
             - ".git"
       - restore_cache:
-          key: v2-npm-{{ checksum "package-lock.json" }}
+          key: v3-npm-{{ checksum "package-lock.json" }}
           keys:
-            - v2-npm-
+            - v3-npm-
       - run: node --version
       - run: npm --version
       - run:
@@ -60,7 +60,7 @@ jobs:
             npm list || true
             pdftops -v
       - save_cache:
-          key: v2-npm-{{ checksum "package-lock.json" }}
+          key: v3-npm-{{ checksum "package-lock.json" }}
           paths:
             - node_modules
       - run:
@@ -101,7 +101,7 @@ jobs:
             - ".git"
       - restore_cache:
           keys:
-            - v2-npm-{{ checksum "package-lock.json" }}
+            - v3-npm-{{ checksum "package-lock.json" }}
       - run:
           name: Build Docker image
           command: |
@@ -121,7 +121,7 @@ jobs:
       - save_cache:
           paths:
             - node_modules
-          key: v2-npm-{{ checksum "package-lock.json" }}
+          key: v3-npm-{{ checksum "package-lock.json" }}
 
   electron-pack-and-release:
     docker:
@@ -138,9 +138,9 @@ jobs:
           paths:
             - ".git"
       - restore_cache:
-          key: v2-npm-{{ checksum "package-lock.json" }}
+          key: v3-npm-{{ checksum "package-lock.json" }}
           keys:
-            - v2-npm-
+            - v3-npm-
       - run: node --version
       - run: npm --version
       - run: npm install
@@ -148,7 +148,7 @@ jobs:
           name: Electron-Builder pack
           command: npm run pack
       - save_cache:
-          key: v2-npm-{{ checksum "package-lock.json" }}
+          key: v3-npm-{{ checksum "package-lock.json" }}
           paths:
             - node_modules
       - run: mkdir artifacts

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,10 +36,19 @@
       "dev": true,
       "optional": true
     },
+    "@sinonjs/formatio": {
+      "version": "2.0.0",
+      "resolved": "http://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
+      "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
+      "dev": true,
+      "requires": {
+        "samsam": "1.3.0"
+      }
+    },
     "@types/node": {
-      "version": "8.10.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.3.tgz",
-      "integrity": "sha512-vjiRZkhKEyZndtFOz/FtIp0CqPbgOOki8o9IcPOLTqlzcnvFLToYdERshLaI6TCz7pDWoKlmvgftqB4xlltn9g==",
+      "version": "8.10.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.8.tgz",
+      "integrity": "sha512-BvcUxNZe9JgiiUVivtiQt3NrPVu9OAQzkxR1Ko9ESftCYU7V6Np5kpDzQwxd+34lsop7SNRdL292Flv52OvCaw==",
       "dev": true
     },
     "accessibility-developer-tools": {
@@ -140,7 +149,7 @@
     "ansi-escapes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
-      "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
+      "integrity": "sha1-7D6LTp+AZPwCw6ybZfHCdb2o75I=",
       "dev": true
     },
     "ansi-regex": {
@@ -206,7 +215,7 @@
         "async": {
           "version": "2.6.0",
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-          "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+          "integrity": "sha1-YaKau2/MAm/qd+VtHG7FOnlZUfQ=",
           "dev": true,
           "requires": {
             "lodash": "4.17.4"
@@ -221,7 +230,7 @@
         "readable-stream": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+          "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
           "dev": true,
           "requires": {
             "core-util-is": "1.0.2",
@@ -236,7 +245,7 @@
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
           "dev": true,
           "requires": {
             "safe-buffer": "5.1.1"
@@ -267,7 +276,7 @@
         "readable-stream": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+          "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
           "dev": true,
           "requires": {
             "core-util-is": "1.0.2",
@@ -282,7 +291,7 @@
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
           "dev": true,
           "requires": {
             "safe-buffer": "5.1.1"
@@ -345,12 +354,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-    },
-    "async": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
-      "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k=",
-      "dev": true
     },
     "async-exit-hook": {
       "version": "2.0.1",
@@ -420,12 +423,6 @@
         "tweetnacl": "0.14.5"
       }
     },
-    "bind-obj-methods": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/bind-obj-methods/-/bind-obj-methods-1.0.0.tgz",
-      "integrity": "sha1-T1l5ysFXk633DkiBYeRj4gnKUJw=",
-      "dev": true
-    },
     "bl": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
@@ -444,7 +441,7 @@
         "readable-stream": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+          "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
           "dev": true,
           "requires": {
             "core-util-is": "1.0.2",
@@ -459,7 +456,7 @@
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
           "dev": true,
           "requires": {
             "safe-buffer": "5.1.1"
@@ -470,7 +467,7 @@
     "bluebird": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
+      "integrity": "sha1-2VUfnemPH82h5oPRfukaBgLuLrk=",
       "dev": true
     },
     "bluebird-lst": {
@@ -604,24 +601,6 @@
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
       "dev": true
-    },
-    "build": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/build/-/build-0.1.4.tgz",
-      "integrity": "sha1-cH/gJv/O3crL/c3zVur9pk8VEEY=",
-      "dev": true,
-      "requires": {
-        "cssmin": "0.3.2",
-        "jsmin": "1.0.1",
-        "jxLoader": "0.1.1",
-        "moo-server": "1.3.0",
-        "promised-io": "0.3.5",
-        "timespan": "2.3.0",
-        "uglify-js": "1.3.5",
-        "walker": "1.0.7",
-        "winston": "2.4.0",
-        "wrench": "1.3.9"
-      }
     },
     "builder-util": {
       "version": "5.7.5",
@@ -826,7 +805,7 @@
     "circular-json": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+      "integrity": "sha1-gVyZ6oT2gJUp0vRXkb34JxE1LWY=",
       "dev": true
     },
     "clean-yaml-object": {
@@ -914,7 +893,7 @@
     "color-convert": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "integrity": "sha1-wSYRB66y8pTr/+ye2eytUppgl+0=",
       "dev": true,
       "requires": {
         "color-name": "1.1.3"
@@ -929,13 +908,7 @@
     "color-support": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
-      "dev": true
-    },
-    "colors": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-      "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+      "integrity": "sha1-k4NDeaHMmgxh+C9S8NBDIiUb1aI=",
       "dev": true
     },
     "combined-stream": {
@@ -945,12 +918,6 @@
       "requires": {
         "delayed-stream": "1.0.0"
       }
-    },
-    "commander": {
-      "version": "2.12.2",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
-      "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
-      "dev": true
     },
     "compare-version": {
       "version": "0.1.2",
@@ -979,7 +946,7 @@
         "readable-stream": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+          "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
           "dev": true,
           "requires": {
             "core-util-is": "1.0.2",
@@ -994,7 +961,7 @@
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
           "dev": true,
           "requires": {
             "safe-buffer": "5.1.1"
@@ -1027,7 +994,7 @@
         "readable-stream": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+          "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
           "dev": true,
           "requires": {
             "core-util-is": "1.0.2",
@@ -1042,7 +1009,7 @@
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
           "dev": true,
           "requires": {
             "safe-buffer": "5.1.1"
@@ -1086,174 +1053,6 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
-    "coveralls": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-2.13.3.tgz",
-      "integrity": "sha512-iiAmn+l1XqRwNLXhW8Rs5qHZRFMYp9ZIPjEOVRpC/c4so6Y/f4/lFi0FfR5B9cCqgyhkJ5cZmbvcVRfP8MHchw==",
-      "dev": true,
-      "requires": {
-        "js-yaml": "3.6.1",
-        "lcov-parse": "0.0.10",
-        "log-driver": "1.2.5",
-        "minimist": "1.2.0",
-        "request": "2.79.0"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
-          "dev": true
-        },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
-          "dev": true
-        },
-        "boom": {
-          "version": "2.10.1",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-          "dev": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "caseless": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-          "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
-          "dev": true
-        },
-        "cryptiles": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-          "dev": true,
-          "requires": {
-            "boom": "2.10.1"
-          }
-        },
-        "esprima": {
-          "version": "2.7.3",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
-          "dev": true
-        },
-        "form-data": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-          "dev": true,
-          "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.17"
-          }
-        },
-        "har-validator": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-          "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
-          "dev": true,
-          "requires": {
-            "chalk": "1.1.3",
-            "commander": "2.12.2",
-            "is-my-json-valid": "2.16.1",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "hawk": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-          "dev": true,
-          "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
-          }
-        },
-        "hoek": {
-          "version": "2.16.3",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-          "dev": true
-        },
-        "http-signature": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-          "dev": true,
-          "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.4.1",
-            "sshpk": "1.13.1"
-          }
-        },
-        "js-yaml": {
-          "version": "3.6.1",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
-          "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
-          "dev": true,
-          "requires": {
-            "argparse": "1.0.9",
-            "esprima": "2.7.3"
-          }
-        },
-        "qs": {
-          "version": "6.3.2",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
-          "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
-          "dev": true
-        },
-        "request": {
-          "version": "2.79.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
-          "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
-          "dev": true,
-          "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
-            "caseless": "0.11.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.1.4",
-            "har-validator": "2.0.6",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.17",
-            "oauth-sign": "0.8.2",
-            "qs": "6.3.2",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.3",
-            "tunnel-agent": "0.4.3",
-            "uuid": "3.2.1"
-          }
-        },
-        "sntp": {
-          "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-          "dev": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
-          "dev": true
-        }
-      }
-    },
     "crc": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/crc/-/crc-3.5.0.tgz",
@@ -1279,7 +1078,7 @@
         "readable-stream": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+          "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
           "dev": true,
           "requires": {
             "core-util-is": "1.0.2",
@@ -1294,7 +1093,7 @@
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
           "dev": true,
           "requires": {
             "safe-buffer": "5.1.1"
@@ -1355,7 +1154,7 @@
         "boom": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+          "integrity": "sha1-XdnabuOl8wIHdDYpDLcX0/SlTgI=",
           "requires": {
             "hoek": "4.2.1"
           }
@@ -1395,12 +1194,6 @@
       "integrity": "sha1-Xv1sLupeof1rasV+wEJ7GEUkJOo=",
       "dev": true
     },
-    "cssmin": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/cssmin/-/cssmin-0.3.2.tgz",
-      "integrity": "sha1-3c5MVHtRCuDVlKjx+/iq+OLFwA0=",
-      "dev": true
-    },
     "currently-unhandled": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
@@ -1409,12 +1202,6 @@
       "requires": {
         "array-find-index": "1.0.2"
       }
-    },
-    "cycle": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
-      "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI=",
-      "dev": true
     },
     "d": {
       "version": "1.0.0",
@@ -1436,7 +1223,7 @@
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
       "dev": true,
       "requires": {
         "ms": "2.0.0"
@@ -1469,7 +1256,7 @@
     "deepmerge": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.0.1.tgz",
-      "integrity": "sha512-VIPwiMJqJ13ZQfaCsIFnp5Me9tnjURiaIFxfz7EH0Ci0dTSQpZtSLrqOicXqEd/z2r+z+Klk9GzmnRsgpgbOsQ==",
+      "integrity": "sha1-JcHCTxEPuRT4AAG5JSZN138/QxI=",
       "dev": true
     },
     "define-properties": {
@@ -1632,7 +1419,7 @@
       "integrity": "sha512-2f1cx0G3riMFODXFftF5AHXy+oHfhpntZHTDN66Hxtl09gmEr42B3piNEod9MEmw72f75LX2JfeYceqq1PF8cA==",
       "dev": true,
       "requires": {
-        "@types/node": "8.10.3",
+        "@types/node": "8.10.8",
         "electron-download": "3.3.0",
         "extract-zip": "1.6.6"
       }
@@ -1836,7 +1623,7 @@
     "electron-chromedriver": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/electron-chromedriver/-/electron-chromedriver-1.8.0.tgz",
-      "integrity": "sha512-m1f3nle5MaGp94bcDTtMZZMMOgPO54+TXoPBlTbBSUjfINR5SJ46yQXLfuE79/qsFfJKslZB1UzWURDDFIRmpQ==",
+      "integrity": "sha1-kBcUEzz29gk9Nl4fRKUtmWJNgkE=",
       "dev": true,
       "requires": {
         "electron-download": "4.1.0",
@@ -1890,7 +1677,7 @@
     "electron-debug": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/electron-debug/-/electron-debug-1.5.0.tgz",
-      "integrity": "sha512-23CLHQXW+gMgdlJbeW1EinPX7DpwuLtfdzSuFL0OnsqEhKGJVJufAZTyq2hc3sr+R53rr3P+mJiYoR5VzAHKJQ==",
+      "integrity": "sha1-2IwCFG77f8WuGyHqxW++SYfq5Qw=",
       "dev": true,
       "requires": {
         "electron-is-dev": "0.3.0",
@@ -1929,7 +1716,7 @@
     "electron-localshortcut": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/electron-localshortcut/-/electron-localshortcut-3.1.0.tgz",
-      "integrity": "sha512-MgL/j5jdjW7iA0R6cI7S045B0GlKXWM1FjjujVPjlrmyXRa6yH0bGSaIAfxXAF9tpJm3pLEiQzerYHkRh9JG/A==",
+      "integrity": "sha1-EMH/1Te405FwqvbhVRNB93gN0s4=",
       "dev": true,
       "requires": {
         "debug": "2.6.9",
@@ -2020,7 +1807,7 @@
     "end-of-stream": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "integrity": "sha1-7SljTRm6ukY7bOa4CjchPqtx7EM=",
       "dev": true,
       "requires": {
         "once": "1.4.0"
@@ -2053,7 +1840,7 @@
     "es-abstract": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.10.0.tgz",
-      "integrity": "sha512-/uh/DhdqIOSkAWifU+8nG78vlQxdLckUdI/sPgy0VhuXi2qJ7T8czBmqIYtLQVpCIFYafChnsRsB5pyb1JdmCQ==",
+      "integrity": "sha1-Hss2wZeEKgDY7kwt/YZGu5fWCGQ=",
       "dev": true,
       "requires": {
         "es-to-primitive": "1.1.1",
@@ -2112,7 +1899,7 @@
     "es6-promise": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
-      "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ==",
+      "integrity": "sha1-3EIhwrFlGHYL2MOaUtjzVvwA7Sk=",
       "dev": true
     },
     "es6-set": {
@@ -2260,7 +2047,7 @@
         "js-yaml": {
           "version": "3.10.0",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-          "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+          "integrity": "sha1-LnhEFka9RoLpY/IrbpKCPDCcYtw=",
           "dev": true,
           "requires": {
             "argparse": "1.0.9",
@@ -2315,7 +2102,7 @@
     "eslint-config-standard-jsx": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-4.0.2.tgz",
-      "integrity": "sha512-F8fRh2WFnTek7dZH9ZaE0PCBwdVGkwVWZmizla/DDNOmg7Tx6B/IlK5+oYpiX29jpu73LszeJj5i1axEZv6VMw==",
+      "integrity": "sha1-AJ5TxN2x6e5wtGUP/mOn85+INuE=",
       "dev": true
     },
     "eslint-import-resolver-node": {
@@ -2332,7 +2119,7 @@
     "eslint-module-utils": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.1.1.tgz",
-      "integrity": "sha512-jDI/X5l/6D1rRD/3T43q8Qgbls2nq5km5KSqiwlyUbGo5+04fXhMKdCPhjwbqAa6HXWaMxj8Q4hQDIh7IadJQw==",
+      "integrity": "sha1-q67IJBd2E7ipWymWOeG2+s9HNEk=",
       "dev": true,
       "requires": {
         "debug": "2.6.9",
@@ -2378,7 +2165,7 @@
     "eslint-plugin-node": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-4.2.3.tgz",
-      "integrity": "sha512-vIUQPuwbVYdz/CYnlTLsJrRy7iXHQjdEe5wz0XhhdTym3IInM/zZLlPf9nZ2mThsH0QcsieCOWs2vOeCy/22LQ==",
+      "integrity": "sha1-wEOQq428u2iHF0Aj1vOnJ2nmO5c=",
       "dev": true,
       "requires": {
         "ignore": "3.3.7",
@@ -2442,7 +2229,7 @@
     "espree": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.2.tgz",
-      "integrity": "sha512-sadKeYwaR/aJ3stC2CdvgXu1T16TdYN+qwCpcWbMnGJ8s0zNWemzrvb2GbD4OhmJ/fwpJjudThAlLobGbWZbCQ==",
+      "integrity": "sha1-dWrai5eenc/NswqtjRqTBKkF4co=",
       "dev": true,
       "requires": {
         "acorn": "5.2.1",
@@ -2452,7 +2239,7 @@
     "esprima": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+      "integrity": "sha1-RJnt3NERDgshi6zy+n9/WfVcqAQ=",
       "dev": true
     },
     "esquery": {
@@ -2544,7 +2331,7 @@
     "external-editor": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
-      "integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
+      "integrity": "sha1-PQJqIbf5W1cmOH1CAKwWDTcsO0g=",
       "dev": true,
       "requires": {
         "chardet": "0.4.2",
@@ -2568,12 +2355,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
-    },
-    "eyes": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
-      "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=",
-      "dev": true
     },
     "fast-deep-equal": {
       "version": "1.1.0",
@@ -2632,7 +2413,7 @@
     "find-root": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
-      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+      "integrity": "sha1-q8/Iunb3CMQql7PWhbfpRQv7nOQ=",
       "dev": true
     },
     "find-up": {
@@ -2766,7 +2547,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=",
       "dev": true
     },
     "function-loop": {
@@ -2827,7 +2608,7 @@
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
       "requires": {
         "fs.realpath": "1.0.0",
         "inflight": "1.0.6",
@@ -2849,7 +2630,7 @@
     "globals": {
       "version": "9.18.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+      "integrity": "sha1-qjiWs+abSH8X4x7SFD1pqOMMLYo=",
       "dev": true
     },
     "globby": {
@@ -2956,7 +2737,7 @@
     "hawk": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+      "integrity": "sha1-r02RTrBl+bXOTZ0RwcshJu7MMDg=",
       "requires": {
         "boom": "4.3.1",
         "cryptiles": "3.1.2",
@@ -2984,7 +2765,7 @@
     "hosted-git-info": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
+      "integrity": "sha1-bWDjSzq7yDEwYsO3mO+NkBoHrzw=",
       "dev": true
     },
     "http-signature": {
@@ -3006,19 +2787,19 @@
     "iconv-lite": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
+      "integrity": "sha1-90aPYBNfXl2tM5nAqBvpoWA6CCs=",
       "dev": true
     },
     "ignore": {
       "version": "3.3.7",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
-      "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
+      "integrity": "sha1-YSKJv7PCIOGGpYEYYY1b6MG6sCE=",
       "dev": true
     },
     "image-size": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.6.2.tgz",
-      "integrity": "sha512-pH3vDzpczdsKHdZ9xxR3O46unSjisgVx0IImay7Zz2EdhRVbCkj+nthx9OuuWEhakx9FAO+fNVGrF0rZ2oMOvw==",
+      "integrity": "sha1-juMW1CmLAouWUJG2c9XxU3re5bQ=",
       "dev": true
     },
     "import-lazy": {
@@ -3059,13 +2840,13 @@
     "ini": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "integrity": "sha1-7uJfVtscnsYIXgwid4CD9Zar+Sc=",
       "dev": true
     },
     "inquirer": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-      "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+      "integrity": "sha1-ndLyrXZdyrH/BEO0kUQqILoifck=",
       "dev": true,
       "requires": {
         "ansi-escapes": "3.0.0",
@@ -3093,7 +2874,7 @@
         "ansi-styles": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
           "dev": true,
           "requires": {
             "color-convert": "1.9.1"
@@ -3102,7 +2883,7 @@
         "chalk": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "integrity": "sha1-tepI78nBeT3MybR2fJORTT8tUro=",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
@@ -3119,7 +2900,7 @@
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "2.0.0",
@@ -3377,23 +3158,11 @@
       "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
       "dev": true
     },
-    "js-yaml": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-0.3.7.tgz",
-      "integrity": "sha1-1znY7oZGHlSzVNan19HyrZoWf2I=",
-      "dev": true
-    },
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "optional": true
-    },
-    "jsmin": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/jsmin/-/jsmin-1.0.1.tgz",
-      "integrity": "sha1-570NzWSWw79IYyNb9GGj2YqjuYw=",
-      "dev": true
     },
     "json-schema": {
       "version": "0.2.3",
@@ -3469,28 +3238,16 @@
       "integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g==",
       "dev": true
     },
-    "jxLoader": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jxLoader/-/jxLoader-0.1.1.tgz",
-      "integrity": "sha1-ATTqUUTlM7WU/B/yX/GU4jXFPs0=",
-      "dev": true,
-      "requires": {
-        "js-yaml": "0.3.7",
-        "moo-server": "1.3.0",
-        "promised-io": "0.3.5",
-        "walker": "1.0.7"
-      }
-    },
     "keyboardevent-from-electron-accelerator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/keyboardevent-from-electron-accelerator/-/keyboardevent-from-electron-accelerator-1.1.0.tgz",
-      "integrity": "sha512-VDC4vKWGrR3VgIKCE4CsXnvObGgP8C2idnTKEMUkuEuvDGE1GEBX9FtNdJzrD00iQlhI3xFxRaeItsUmlERVng==",
+      "integrity": "sha1-MkYU9uM0kMN//Fvlh2s+hf4iPIQ=",
       "dev": true
     },
     "keyboardevents-areequal": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/keyboardevents-areequal/-/keyboardevents-areequal-0.2.2.tgz",
-      "integrity": "sha512-Nv+Kr33T0mEjxR500q+I6IWisOQ0lK1GGOncV0kWE6n4KFmpcu7RUX5/2B0EUtX51Cb0HjZ9VJsSY3u4cBa0kw==",
+      "integrity": "sha1-iBkexzjOn3WRwl6QVt6Si0AncZQ=",
       "dev": true
     },
     "klaw": {
@@ -3535,7 +3292,7 @@
         "readable-stream": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+          "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
           "dev": true,
           "requires": {
             "core-util-is": "1.0.2",
@@ -3550,7 +3307,7 @@
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
           "dev": true,
           "requires": {
             "safe-buffer": "5.1.1"
@@ -3687,15 +3444,6 @@
         }
       }
     },
-    "makeerror": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
-      "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
-      "dev": true,
-      "requires": {
-        "tmpl": "1.0.4"
-      }
-    },
     "map-obj": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
@@ -3757,7 +3505,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "requires": {
         "brace-expansion": "1.1.8"
       }
@@ -3766,6 +3514,24 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+    },
+    "minipass": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
+      "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1",
+        "yallist": "3.0.2"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
+          "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
+          "dev": true
+        }
+      }
     },
     "mkdirp": {
       "version": "0.5.0",
@@ -3784,12 +3550,6 @@
         }
       }
     },
-    "moo-server": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/moo-server/-/moo-server-1.3.0.tgz",
-      "integrity": "sha1-XceVaVZaENbv7VQ5SR5p0jkuWPE=",
-      "dev": true
-    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -3800,12 +3560,6 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
-      "dev": true
-    },
-    "native-promise-only": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
-      "integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE=",
       "dev": true
     },
     "natural-compare": {
@@ -3838,7 +3592,7 @@
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
       "dev": true,
       "requires": {
         "hosted-git-info": "2.5.0",
@@ -3891,1600 +3645,6 @@
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
-    },
-    "nyc": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/nyc/-/nyc-11.3.0.tgz",
-      "integrity": "sha512-oUu0WHt1k/JMIODvAYXX6C50Mupw2GO34P/Jdg2ty9xrLufBthHiKR2gf08aF+9S0abW1fl24R7iKRBXzibZmg==",
-      "dev": true,
-      "requires": {
-        "archy": "1.0.0",
-        "arrify": "1.0.1",
-        "caching-transform": "1.0.1",
-        "convert-source-map": "1.5.0",
-        "debug-log": "1.0.1",
-        "default-require-extensions": "1.0.0",
-        "find-cache-dir": "0.1.1",
-        "find-up": "2.1.0",
-        "foreground-child": "1.5.6",
-        "glob": "7.1.2",
-        "istanbul-lib-coverage": "1.1.1",
-        "istanbul-lib-hook": "1.1.0",
-        "istanbul-lib-instrument": "1.9.1",
-        "istanbul-lib-report": "1.1.2",
-        "istanbul-lib-source-maps": "1.2.2",
-        "istanbul-reports": "1.1.3",
-        "md5-hex": "1.3.0",
-        "merge-source-map": "1.0.4",
-        "micromatch": "2.3.11",
-        "mkdirp": "0.5.1",
-        "resolve-from": "2.0.0",
-        "rimraf": "2.6.2",
-        "signal-exit": "3.0.2",
-        "spawn-wrap": "1.3.8",
-        "test-exclude": "4.1.1",
-        "yargs": "10.0.3",
-        "yargs-parser": "8.0.0"
-      },
-      "dependencies": {
-        "align-text": {
-          "version": "0.1.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "kind-of": "3.2.2",
-            "longest": "1.0.1",
-            "repeat-string": "1.6.1"
-          }
-        },
-        "amdefine": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "bundled": true,
-          "dev": true
-        },
-        "append-transform": {
-          "version": "0.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "default-require-extensions": "1.0.0"
-          }
-        },
-        "archy": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "arr-diff": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "arr-flatten": "1.1.0"
-          }
-        },
-        "arr-flatten": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "array-unique": {
-          "version": "0.2.1",
-          "bundled": true,
-          "dev": true
-        },
-        "arrify": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "async": {
-          "version": "1.5.2",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-code-frame": {
-          "version": "6.26.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "chalk": "1.1.3",
-            "esutils": "2.0.2",
-            "js-tokens": "3.0.2"
-          }
-        },
-        "babel-generator": {
-          "version": "6.26.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "detect-indent": "4.0.0",
-            "jsesc": "1.3.0",
-            "lodash": "4.17.4",
-            "source-map": "0.5.7",
-            "trim-right": "1.0.1"
-          }
-        },
-        "babel-messages": {
-          "version": "6.23.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "babel-runtime": "6.26.0"
-          }
-        },
-        "babel-runtime": {
-          "version": "6.26.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "core-js": "2.5.1",
-            "regenerator-runtime": "0.11.0"
-          }
-        },
-        "babel-template": {
-          "version": "6.26.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "lodash": "4.17.4"
-          }
-        },
-        "babel-traverse": {
-          "version": "6.26.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "babel-code-frame": "6.26.0",
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "debug": "2.6.9",
-            "globals": "9.18.0",
-            "invariant": "2.2.2",
-            "lodash": "4.17.4"
-          }
-        },
-        "babel-types": {
-          "version": "6.26.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "babel-runtime": "6.26.0",
-            "esutils": "2.0.2",
-            "lodash": "4.17.4",
-            "to-fast-properties": "1.0.3"
-          }
-        },
-        "babylon": {
-          "version": "6.18.0",
-          "bundled": true,
-          "dev": true
-        },
-        "balanced-match": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "brace-expansion": {
-          "version": "1.1.8",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "balanced-match": "1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "braces": {
-          "version": "1.8.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "expand-range": "1.8.2",
-            "preserve": "0.2.0",
-            "repeat-element": "1.1.2"
-          }
-        },
-        "builtin-modules": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "caching-transform": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "md5-hex": "1.3.0",
-            "mkdirp": "0.5.1",
-            "write-file-atomic": "1.3.4"
-          }
-        },
-        "camelcase": {
-          "version": "1.2.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "center-align": {
-          "version": "0.1.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "align-text": "0.1.4",
-            "lazy-cache": "1.0.4"
-          }
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
-        "cliui": {
-          "version": "2.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "center-align": "0.1.3",
-            "right-align": "0.1.3",
-            "wordwrap": "0.0.2"
-          },
-          "dependencies": {
-            "wordwrap": {
-              "version": "0.0.2",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "commondir": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "convert-source-map": {
-          "version": "1.5.0",
-          "bundled": true,
-          "dev": true
-        },
-        "core-js": {
-          "version": "2.5.1",
-          "bundled": true,
-          "dev": true
-        },
-        "cross-spawn": {
-          "version": "4.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "lru-cache": "4.1.1",
-            "which": "1.3.0"
-          }
-        },
-        "debug": {
-          "version": "2.6.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "debug-log": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "decamelize": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true
-        },
-        "default-require-extensions": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "strip-bom": "2.0.0"
-          }
-        },
-        "detect-indent": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "repeating": "2.0.1"
-          }
-        },
-        "error-ex": {
-          "version": "1.3.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-arrayish": "0.2.1"
-          }
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true
-        },
-        "esutils": {
-          "version": "2.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "execa": {
-          "version": "0.7.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "cross-spawn": "5.1.0",
-            "get-stream": "3.0.0",
-            "is-stream": "1.1.0",
-            "npm-run-path": "2.0.2",
-            "p-finally": "1.0.0",
-            "signal-exit": "3.0.2",
-            "strip-eof": "1.0.0"
-          },
-          "dependencies": {
-            "cross-spawn": {
-              "version": "5.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "lru-cache": "4.1.1",
-                "shebang-command": "1.2.0",
-                "which": "1.3.0"
-              }
-            }
-          }
-        },
-        "expand-brackets": {
-          "version": "0.1.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-posix-bracket": "0.1.1"
-          }
-        },
-        "expand-range": {
-          "version": "1.8.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "fill-range": "2.2.3"
-          }
-        },
-        "extglob": {
-          "version": "0.3.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-extglob": "1.0.0"
-          }
-        },
-        "filename-regex": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "fill-range": {
-          "version": "2.2.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-number": "2.1.0",
-            "isobject": "2.1.0",
-            "randomatic": "1.1.7",
-            "repeat-element": "1.1.2",
-            "repeat-string": "1.6.1"
-          }
-        },
-        "find-cache-dir": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "commondir": "1.0.1",
-            "mkdirp": "0.5.1",
-            "pkg-dir": "1.0.0"
-          }
-        },
-        "find-up": {
-          "version": "2.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "locate-path": "2.0.0"
-          }
-        },
-        "for-in": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "for-own": {
-          "version": "0.1.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "for-in": "1.0.2"
-          }
-        },
-        "foreground-child": {
-          "version": "1.5.6",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "cross-spawn": "4.0.2",
-            "signal-exit": "3.0.2"
-          }
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "get-caller-file": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "get-stream": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "glob": {
-          "version": "7.1.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
-        "glob-base": {
-          "version": "0.3.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "glob-parent": "2.0.0",
-            "is-glob": "2.0.1"
-          }
-        },
-        "glob-parent": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-glob": "2.0.1"
-          }
-        },
-        "globals": {
-          "version": "9.18.0",
-          "bundled": true,
-          "dev": true
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "bundled": true,
-          "dev": true
-        },
-        "handlebars": {
-          "version": "4.0.11",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "async": "1.5.2",
-            "optimist": "0.6.1",
-            "source-map": "0.4.4",
-            "uglify-js": "2.8.29"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.4.4",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "amdefine": "1.0.1"
-              }
-            }
-          }
-        },
-        "has-ansi": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "has-flag": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "hosted-git-info": {
-          "version": "2.5.0",
-          "bundled": true,
-          "dev": true
-        },
-        "imurmurhash": {
-          "version": "0.1.4",
-          "bundled": true,
-          "dev": true
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "invariant": {
-          "version": "2.2.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "loose-envify": "1.3.1"
-          }
-        },
-        "invert-kv": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "is-arrayish": {
-          "version": "0.2.1",
-          "bundled": true,
-          "dev": true
-        },
-        "is-buffer": {
-          "version": "1.1.5",
-          "bundled": true,
-          "dev": true
-        },
-        "is-builtin-module": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "builtin-modules": "1.1.1"
-          }
-        },
-        "is-dotfile": {
-          "version": "1.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "is-equal-shallow": {
-          "version": "0.1.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-primitive": "2.0.0"
-          }
-        },
-        "is-extendable": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "is-extglob": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "is-finite": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-extglob": "1.0.0"
-          }
-        },
-        "is-number": {
-          "version": "2.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          }
-        },
-        "is-posix-bracket": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "is-primitive": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "is-stream": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "is-utf8": {
-          "version": "0.2.1",
-          "bundled": true,
-          "dev": true
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "isexe": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "isobject": {
-          "version": "2.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "isarray": "1.0.0"
-          }
-        },
-        "istanbul-lib-coverage": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "istanbul-lib-hook": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "append-transform": "0.4.0"
-          }
-        },
-        "istanbul-lib-instrument": {
-          "version": "1.9.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "babel-generator": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "istanbul-lib-coverage": "1.1.1",
-            "semver": "5.4.1"
-          }
-        },
-        "istanbul-lib-report": {
-          "version": "1.1.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "istanbul-lib-coverage": "1.1.1",
-            "mkdirp": "0.5.1",
-            "path-parse": "1.0.5",
-            "supports-color": "3.2.3"
-          },
-          "dependencies": {
-            "supports-color": {
-              "version": "3.2.3",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "has-flag": "1.0.0"
-              }
-            }
-          }
-        },
-        "istanbul-lib-source-maps": {
-          "version": "1.2.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "debug": "3.1.0",
-            "istanbul-lib-coverage": "1.1.1",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.2",
-            "source-map": "0.5.7"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "3.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            }
-          }
-        },
-        "istanbul-reports": {
-          "version": "1.1.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "handlebars": "4.0.11"
-          }
-        },
-        "js-tokens": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "jsesc": {
-          "version": "1.3.0",
-          "bundled": true,
-          "dev": true
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-buffer": "1.1.5"
-          }
-        },
-        "lazy-cache": {
-          "version": "1.0.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "lcid": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "invert-kv": "1.0.0"
-          }
-        },
-        "load-json-file": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "p-locate": "2.0.0",
-            "path-exists": "3.0.0"
-          },
-          "dependencies": {
-            "path-exists": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "lodash": {
-          "version": "4.17.4",
-          "bundled": true,
-          "dev": true
-        },
-        "longest": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "loose-envify": {
-          "version": "1.3.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "js-tokens": "3.0.2"
-          }
-        },
-        "lru-cache": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "pseudomap": "1.0.2",
-            "yallist": "2.1.2"
-          }
-        },
-        "md5-hex": {
-          "version": "1.3.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "md5-o-matic": "0.1.1"
-          }
-        },
-        "md5-o-matic": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "mem": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "mimic-fn": "1.1.0"
-          }
-        },
-        "merge-source-map": {
-          "version": "1.0.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "source-map": "0.5.7"
-          }
-        },
-        "micromatch": {
-          "version": "2.3.11",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "arr-diff": "2.0.0",
-            "array-unique": "0.2.1",
-            "braces": "1.8.5",
-            "expand-brackets": "0.1.5",
-            "extglob": "0.3.2",
-            "filename-regex": "2.0.1",
-            "is-extglob": "1.0.0",
-            "is-glob": "2.0.1",
-            "kind-of": "3.2.2",
-            "normalize-path": "2.1.1",
-            "object.omit": "2.0.1",
-            "parse-glob": "3.0.4",
-            "regex-cache": "0.4.4"
-          }
-        },
-        "mimic-fn": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "brace-expansion": "1.1.8"
-          }
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "bundled": true,
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "normalize-package-data": {
-          "version": "2.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "hosted-git-info": "2.5.0",
-            "is-builtin-module": "1.0.0",
-            "semver": "5.4.1",
-            "validate-npm-package-license": "3.0.1"
-          }
-        },
-        "normalize-path": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "remove-trailing-separator": "1.1.0"
-          }
-        },
-        "npm-run-path": {
-          "version": "2.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "path-key": "2.0.1"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "object.omit": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "for-own": "0.1.5",
-            "is-extendable": "0.1.1"
-          }
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "wrappy": "1.0.2"
-          }
-        },
-        "optimist": {
-          "version": "0.6.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8",
-            "wordwrap": "0.0.3"
-          }
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "os-locale": {
-          "version": "2.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "execa": "0.7.0",
-            "lcid": "1.0.0",
-            "mem": "1.1.0"
-          }
-        },
-        "p-finally": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "p-limit": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "p-locate": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "p-limit": "1.1.0"
-          }
-        },
-        "parse-glob": {
-          "version": "3.0.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "glob-base": "0.3.0",
-            "is-dotfile": "1.0.3",
-            "is-extglob": "1.0.0",
-            "is-glob": "2.0.1"
-          }
-        },
-        "parse-json": {
-          "version": "2.2.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "error-ex": "1.3.1"
-          }
-        },
-        "path-exists": {
-          "version": "2.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "path-key": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "path-parse": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true
-        },
-        "path-type": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "pify": {
-          "version": "2.3.0",
-          "bundled": true,
-          "dev": true
-        },
-        "pinkie": {
-          "version": "2.0.4",
-          "bundled": true,
-          "dev": true
-        },
-        "pinkie-promise": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "pinkie": "2.0.4"
-          }
-        },
-        "pkg-dir": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "find-up": "1.1.2"
-          },
-          "dependencies": {
-            "find-up": {
-              "version": "1.1.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "path-exists": "2.1.0",
-                "pinkie-promise": "2.0.1"
-              }
-            }
-          }
-        },
-        "preserve": {
-          "version": "0.2.0",
-          "bundled": true,
-          "dev": true
-        },
-        "pseudomap": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "randomatic": {
-          "version": "1.1.7",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-number": "3.0.0",
-            "kind-of": "4.0.0"
-          },
-          "dependencies": {
-            "is-number": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "kind-of": "3.2.2"
-              },
-              "dependencies": {
-                "kind-of": {
-                  "version": "3.2.2",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "is-buffer": "1.1.5"
-                  }
-                }
-              }
-            },
-            "kind-of": {
-              "version": "4.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-buffer": "1.1.5"
-              }
-            }
-          }
-        },
-        "read-pkg": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "1.1.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
-          },
-          "dependencies": {
-            "find-up": {
-              "version": "1.1.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "path-exists": "2.1.0",
-                "pinkie-promise": "2.0.1"
-              }
-            }
-          }
-        },
-        "regenerator-runtime": {
-          "version": "0.11.0",
-          "bundled": true,
-          "dev": true
-        },
-        "regex-cache": {
-          "version": "0.4.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-equal-shallow": "0.1.3"
-          }
-        },
-        "remove-trailing-separator": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "repeat-element": {
-          "version": "1.1.2",
-          "bundled": true,
-          "dev": true
-        },
-        "repeat-string": {
-          "version": "1.6.1",
-          "bundled": true,
-          "dev": true
-        },
-        "repeating": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-finite": "1.0.2"
-          }
-        },
-        "require-directory": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "require-main-filename": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "resolve-from": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "right-align": {
-          "version": "0.1.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "align-text": "0.1.4"
-          }
-        },
-        "rimraf": {
-          "version": "2.6.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "glob": "7.1.2"
-          }
-        },
-        "semver": {
-          "version": "5.4.1",
-          "bundled": true,
-          "dev": true
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "shebang-command": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "shebang-regex": "1.0.0"
-          }
-        },
-        "shebang-regex": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "slide": {
-          "version": "1.1.6",
-          "bundled": true,
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "bundled": true,
-          "dev": true
-        },
-        "spawn-wrap": {
-          "version": "1.3.8",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "foreground-child": "1.5.6",
-            "mkdirp": "0.5.1",
-            "os-homedir": "1.0.2",
-            "rimraf": "2.6.2",
-            "signal-exit": "3.0.2",
-            "which": "1.3.0"
-          }
-        },
-        "spdx-correct": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "spdx-license-ids": "1.2.2"
-          }
-        },
-        "spdx-expression-parse": {
-          "version": "1.0.4",
-          "bundled": true,
-          "dev": true
-        },
-        "spdx-license-ids": {
-          "version": "1.2.2",
-          "bundled": true,
-          "dev": true
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "is-fullwidth-code-point": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "strip-ansi": {
-              "version": "4.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "ansi-regex": "3.0.0"
-              }
-            }
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "strip-bom": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-utf8": "0.2.1"
-          }
-        },
-        "strip-eof": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "test-exclude": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "arrify": "1.0.1",
-            "micromatch": "2.3.11",
-            "object-assign": "4.1.1",
-            "read-pkg-up": "1.0.1",
-            "require-main-filename": "1.0.1"
-          }
-        },
-        "to-fast-properties": {
-          "version": "1.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "trim-right": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "uglify-js": {
-          "version": "2.8.29",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "source-map": "0.5.7",
-            "uglify-to-browserify": "1.0.2",
-            "yargs": "3.10.0"
-          },
-          "dependencies": {
-            "yargs": {
-              "version": "3.10.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "camelcase": "1.2.1",
-                "cliui": "2.1.0",
-                "decamelize": "1.2.0",
-                "window-size": "0.1.0"
-              }
-            }
-          }
-        },
-        "uglify-to-browserify": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "validate-npm-package-license": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "spdx-correct": "1.0.2",
-            "spdx-expression-parse": "1.0.4"
-          }
-        },
-        "which": {
-          "version": "1.3.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "isexe": "2.0.0"
-          }
-        },
-        "which-module": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "window-size": {
-          "version": "0.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "wordwrap": {
-          "version": "0.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "wrap-ansi": {
-          "version": "2.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1"
-          },
-          "dependencies": {
-            "string-width": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
-              }
-            }
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "write-file-atomic": {
-          "version": "1.3.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "imurmurhash": "0.1.4",
-            "slide": "1.1.6"
-          }
-        },
-        "y18n": {
-          "version": "3.2.1",
-          "bundled": true,
-          "dev": true
-        },
-        "yallist": {
-          "version": "2.1.2",
-          "bundled": true,
-          "dev": true
-        },
-        "yargs": {
-          "version": "10.0.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "find-up": "2.1.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "2.1.0",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "2.1.1",
-            "which-module": "2.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "8.0.0"
-          },
-          "dependencies": {
-            "cliui": {
-              "version": "3.2.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1",
-                "wrap-ansi": "2.1.0"
-              },
-              "dependencies": {
-                "string-width": {
-                  "version": "1.0.2",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "code-point-at": "1.1.0",
-                    "is-fullwidth-code-point": "1.0.0",
-                    "strip-ansi": "3.0.1"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "yargs-parser": {
-          "version": "8.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "camelcase": "4.1.0"
-          },
-          "dependencies": {
-            "camelcase": {
-              "version": "4.1.0",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        }
-      }
     },
     "oauth-sign": {
       "version": "0.8.2",
@@ -5612,12 +3772,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/own-or/-/own-or-1.0.0.tgz",
       "integrity": "sha1-Tod/vtqaLsgAD7wLyuOWRe6L+Nw=",
-      "dev": true
-    },
-    "own-or-env": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/own-or-env/-/own-or-env-1.0.0.tgz",
-      "integrity": "sha1-nvkg/IHi5jz1nUEQElg2jPT8pPs=",
       "dev": true
     },
     "p-finally": {
@@ -5913,12 +4067,6 @@
         "through2": "0.2.3"
       }
     },
-    "promised-io": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/promised-io/-/promised-io-0.3.5.tgz",
-      "integrity": "sha1-StIXuzZYvKrplGsXqGaOzYUeE1Y=",
-      "dev": true
-    },
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
@@ -5939,7 +4087,7 @@
     "qs": {
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+      "integrity": "sha1-NJzfbu+J7EXBLX1es/wMhwNDptg="
     },
     "querystring": {
       "version": "0.2.0",
@@ -6093,7 +4241,7 @@
     "regenerator-runtime": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+      "integrity": "sha1-vgWtf5v30i4Fb5cmzuUBf78Z4uk=",
       "dev": true
     },
     "registry-auth-token": {
@@ -6184,7 +4332,7 @@
     "resolve": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
-      "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+      "integrity": "sha1-HwmsznlsmnYlefMbLBzEw83fnzY=",
       "dev": true,
       "requires": {
         "path-parse": "1.0.5"
@@ -6221,7 +4369,7 @@
     "rimraf": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
       "dev": true,
       "requires": {
         "glob": "7.1.2"
@@ -6269,7 +4417,7 @@
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+      "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM="
     },
     "safe-json-parse": {
       "version": "1.0.1",
@@ -6279,7 +4427,7 @@
     "samsam": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
-      "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
+      "integrity": "sha1-jR2TUOJWItow3j5EumkrUiGrfFA=",
       "dev": true
     },
     "sanitize-filename": {
@@ -6300,7 +4448,7 @@
     "semver": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+      "integrity": "sha1-3Eu8emyp2Rbe5dQ1FvAJK1j3uKs="
     },
     "semver-diff": {
       "version": "2.1.0",
@@ -6359,22 +4507,35 @@
       }
     },
     "sinon": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-3.3.0.tgz",
-      "integrity": "sha512-/flfGfIxIRXSvZBHJzIf3iAyGYkmMQq6SQjA0cx9SOuVuq+4ZPPO4LJtH1Ce0Lznax1KSG1U6Dad85wIcSW19w==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.5.0.tgz",
+      "integrity": "sha512-trdx+mB0VBBgoYucy6a9L7/jfQOmvGeaKZT4OOJ+lPAtI8623xyGr8wLiE4eojzBS8G9yXbhx42GHUOVLr4X2w==",
       "dev": true,
       "requires": {
-        "build": "0.1.4",
+        "@sinonjs/formatio": "2.0.0",
         "diff": "3.4.0",
-        "formatio": "1.2.0",
         "lodash.get": "4.4.2",
         "lolex": "2.3.1",
-        "native-promise-only": "0.8.1",
         "nise": "1.2.0",
-        "path-to-regexp": "1.7.0",
-        "samsam": "1.3.0",
-        "text-encoding": "0.6.4",
+        "supports-color": "5.3.0",
         "type-detect": "4.0.5"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
       }
     },
     "slice-ansi": {
@@ -6489,7 +4650,7 @@
     "sntp": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
-      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+      "integrity": "sha1-LGzsFP7cIiJznK+bXD2F0cxaLMg=",
       "requires": {
         "hoek": "4.2.1"
       }
@@ -6513,23 +4674,6 @@
         "resolve-url": "0.2.1",
         "source-map-url": "0.3.0",
         "urix": "0.1.0"
-      }
-    },
-    "source-map-support": {
-      "version": "0.4.18",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
-      "dev": true,
-      "requires": {
-        "source-map": "0.5.7"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
-        }
       }
     },
     "source-map-url": {
@@ -6562,7 +4706,7 @@
     "spectron": {
       "version": "3.8.0",
       "resolved": "https://registry.npmjs.org/spectron/-/spectron-3.8.0.tgz",
-      "integrity": "sha512-fQ7gFp6UuEaONjXFLifLeIUI022pOsm3b+NFAm696r2umUkSZ9IbnEgHwrvBX+pJ3QUDyCEs5bPHUieYU7FvaQ==",
+      "integrity": "sha1-Eiw1Yv1+krfN9vlAlKpJWxUN+lE=",
       "dev": true,
       "requires": {
         "dev-null": "0.1.1",
@@ -6581,7 +4725,7 @@
     "split": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "integrity": "sha1-YFvZvjA6pZ+zX5Ip++oN3snqB9k=",
       "dev": true,
       "requires": {
         "through": "2.3.8"
@@ -6608,12 +4752,6 @@
         "tweetnacl": "0.14.5"
       }
     },
-    "stack-trace": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
-      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
-      "dev": true
-    },
     "stack-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.1.tgz",
@@ -6623,7 +4761,7 @@
     "standard": {
       "version": "10.0.3",
       "resolved": "https://registry.npmjs.org/standard/-/standard-10.0.3.tgz",
-      "integrity": "sha512-JURZ+85ExKLQULckDFijdX5WHzN6RC7fgiZNSV4jFQVo+3tPoQGHyBrGekye/yf0aOfb4210EM5qPNlc2cRh4w==",
+      "integrity": "sha1-eGm8v0Ir3uqraJof+x/qlnfdUOo=",
       "dev": true,
       "requires": {
         "eslint": "3.19.0",
@@ -6686,7 +4824,7 @@
         "readable-stream": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+          "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
           "requires": {
             "core-util-is": "1.0.2",
             "inherits": "2.0.3",
@@ -6700,7 +4838,7 @@
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
           "requires": {
             "safe-buffer": "5.1.1"
           }
@@ -6830,7 +4968,7 @@
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "2.0.0",
@@ -6849,98 +4987,61 @@
       }
     },
     "tap": {
-      "version": "10.7.3",
-      "resolved": "https://registry.npmjs.org/tap/-/tap-10.7.3.tgz",
-      "integrity": "sha512-oS/FIq+tcmxVgYn5usKtLsX+sOHNEj+G7JIQE9SBjO5mVYB1rbaEJJiDbnYp8k0ZqY2Pe4HbYEpkvzm9jfLDyw==",
+      "version": "11.1.3",
+      "resolved": "https://registry.npmjs.org/tap/-/tap-11.1.3.tgz",
+      "integrity": "sha512-DwiAZiQWzALkGEbhhbdi+DqT2nqmqFAJZRvVSnHBpA8khjf7+6kcO76Bx39JA7kclIfQ9Uro1rO4dgP1AWUovw==",
       "dev": true,
       "requires": {
-        "bind-obj-methods": "1.0.0",
+        "bind-obj-methods": "2.0.0",
         "bluebird": "3.5.1",
         "clean-yaml-object": "0.1.0",
         "color-support": "1.1.3",
-        "coveralls": "2.13.3",
+        "coveralls": "3.0.0",
         "foreground-child": "1.5.6",
         "fs-exists-cached": "1.0.0",
         "function-loop": "1.0.1",
         "glob": "7.1.2",
         "isexe": "2.0.0",
-        "js-yaml": "3.10.0",
-        "nyc": "11.3.0",
+        "js-yaml": "3.11.0",
+        "minipass": "2.2.4",
+        "mkdirp": "0.5.1",
+        "nyc": "11.6.0",
         "opener": "1.4.3",
         "os-homedir": "1.0.2",
         "own-or": "1.0.0",
-        "own-or-env": "1.0.0",
-        "readable-stream": "2.3.3",
+        "own-or-env": "1.0.1",
+        "rimraf": "2.6.2",
         "signal-exit": "3.0.2",
-        "source-map-support": "0.4.18",
+        "source-map-support": "0.5.4",
         "stack-utils": "1.0.1",
-        "tap-mocha-reporter": "3.0.6",
-        "tap-parser": "5.4.0",
+        "tap-mocha-reporter": "3.0.7",
+        "tap-parser": "7.0.0",
         "tmatch": "3.1.0",
         "trivial-deferred": "1.0.1",
         "tsame": "1.1.2",
+        "write-file-atomic": "2.3.0",
         "yapool": "1.0.0"
       },
       "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+        "bind-obj-methods": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/bind-obj-methods/-/bind-obj-methods-2.0.0.tgz",
+          "integrity": "sha512-3/qRXczDi2Cdbz6jE+W3IflJOutRVica8frpBn14de1mBOkzDo+6tY33kNhvkw54Kn3PzRRD2VnGbGPcTAk4sw==",
           "dev": true
         },
-        "js-yaml": {
-          "version": "3.10.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-          "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+        "coveralls": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.0.tgz",
+          "integrity": "sha512-ZppXR9y5PraUOrf/DzHJY6gzNUhXYE3b9D43xEXs4QYZ7/Oe0Gy0CS+IPKWFfvQFXB3RG9QduaQUFehzSpGAFw==",
           "dev": true,
           "requires": {
-            "argparse": "1.0.9",
-            "esprima": "4.0.0"
+            "js-yaml": "3.11.0",
+            "lcov-parse": "0.0.10",
+            "log-driver": "1.2.5",
+            "minimist": "1.2.0",
+            "request": "2.85.0"
           }
         },
-        "readable-stream": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        }
-      }
-    },
-    "tap-mocha-reporter": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/tap-mocha-reporter/-/tap-mocha-reporter-3.0.6.tgz",
-      "integrity": "sha512-UImgw3etckDQCoqZIAIKcQDt0w1JLVs3v0yxLlmwvGLZl6MGFxF7JME5PElXjAoDklVDU42P3vVu5jgr37P4Yg==",
-      "dev": true,
-      "requires": {
-        "color-support": "1.1.3",
-        "debug": "2.6.9",
-        "diff": "1.4.0",
-        "escape-string-regexp": "1.0.5",
-        "glob": "7.1.2",
-        "js-yaml": "3.10.0",
-        "readable-stream": "2.3.3",
-        "tap-parser": "5.4.0",
-        "unicode-length": "1.0.3"
-      },
-      "dependencies": {
         "diff": {
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
@@ -6955,95 +5056,2899 @@
           "optional": true
         },
         "js-yaml": {
-          "version": "3.10.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-          "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+          "version": "3.11.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
+          "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
           "dev": true,
           "requires": {
             "argparse": "1.0.9",
             "esprima": "4.0.0"
           }
         },
-        "readable-stream": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
-          "optional": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
+            "minimist": "0.0.8"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+              "dev": true
+            }
           }
         },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+        "nyc": {
+          "version": "11.6.0",
+          "resolved": "https://registry.npmjs.org/nyc/-/nyc-11.6.0.tgz",
+          "integrity": "sha512-ZaXCh0wmbk2aSBH2B5hZGGvK2s9aM8DIm2rVY+BG3Fx8tUS+bpJSswUVZqOD1YfCmnYRFSqgYJSr7UeeUcW0jg==",
           "dev": true,
-          "optional": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "archy": "1.0.0",
+            "arrify": "1.0.1",
+            "caching-transform": "1.0.1",
+            "convert-source-map": "1.5.1",
+            "debug-log": "1.0.1",
+            "default-require-extensions": "1.0.0",
+            "find-cache-dir": "0.1.1",
+            "find-up": "2.1.0",
+            "foreground-child": "1.5.6",
+            "glob": "7.1.2",
+            "istanbul-lib-coverage": "1.2.0",
+            "istanbul-lib-hook": "1.1.0",
+            "istanbul-lib-instrument": "1.10.1",
+            "istanbul-lib-report": "1.1.3",
+            "istanbul-lib-source-maps": "1.2.3",
+            "istanbul-reports": "1.3.0",
+            "md5-hex": "1.3.0",
+            "merge-source-map": "1.1.0",
+            "micromatch": "2.3.11",
+            "mkdirp": "0.5.1",
+            "resolve-from": "2.0.0",
+            "rimraf": "2.6.2",
+            "signal-exit": "3.0.2",
+            "spawn-wrap": "1.4.2",
+            "test-exclude": "4.2.1",
+            "yargs": "11.1.0",
+            "yargs-parser": "8.1.0"
+          },
+          "dependencies": {
+            "align-text": {
+              "version": "0.1.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "kind-of": "3.2.2",
+                "longest": "1.0.1",
+                "repeat-string": "1.6.1"
+              }
+            },
+            "amdefine": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "ansi-regex": {
+              "version": "2.1.1",
+              "bundled": true,
+              "dev": true
+            },
+            "ansi-styles": {
+              "version": "2.2.1",
+              "bundled": true,
+              "dev": true
+            },
+            "append-transform": {
+              "version": "0.4.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "default-require-extensions": "1.0.0"
+              }
+            },
+            "archy": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "arr-diff": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "arr-flatten": "1.1.0"
+              }
+            },
+            "arr-flatten": {
+              "version": "1.1.0",
+              "bundled": true,
+              "dev": true
+            },
+            "arr-union": {
+              "version": "3.1.0",
+              "bundled": true,
+              "dev": true
+            },
+            "array-unique": {
+              "version": "0.2.1",
+              "bundled": true,
+              "dev": true
+            },
+            "arrify": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "assign-symbols": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "async": {
+              "version": "1.5.2",
+              "bundled": true,
+              "dev": true
+            },
+            "atob": {
+              "version": "2.0.3",
+              "bundled": true,
+              "dev": true
+            },
+            "babel-code-frame": {
+              "version": "6.26.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "chalk": "1.1.3",
+                "esutils": "2.0.2",
+                "js-tokens": "3.0.2"
+              }
+            },
+            "babel-generator": {
+              "version": "6.26.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "babel-messages": "6.23.0",
+                "babel-runtime": "6.26.0",
+                "babel-types": "6.26.0",
+                "detect-indent": "4.0.0",
+                "jsesc": "1.3.0",
+                "lodash": "4.17.5",
+                "source-map": "0.5.7",
+                "trim-right": "1.0.1"
+              }
+            },
+            "babel-messages": {
+              "version": "6.23.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "babel-runtime": "6.26.0"
+              }
+            },
+            "babel-runtime": {
+              "version": "6.26.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "core-js": "2.5.3",
+                "regenerator-runtime": "0.11.1"
+              }
+            },
+            "babel-template": {
+              "version": "6.26.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "babel-runtime": "6.26.0",
+                "babel-traverse": "6.26.0",
+                "babel-types": "6.26.0",
+                "babylon": "6.18.0",
+                "lodash": "4.17.5"
+              }
+            },
+            "babel-traverse": {
+              "version": "6.26.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "babel-code-frame": "6.26.0",
+                "babel-messages": "6.23.0",
+                "babel-runtime": "6.26.0",
+                "babel-types": "6.26.0",
+                "babylon": "6.18.0",
+                "debug": "2.6.9",
+                "globals": "9.18.0",
+                "invariant": "2.2.3",
+                "lodash": "4.17.5"
+              }
+            },
+            "babel-types": {
+              "version": "6.26.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "babel-runtime": "6.26.0",
+                "esutils": "2.0.2",
+                "lodash": "4.17.5",
+                "to-fast-properties": "1.0.3"
+              }
+            },
+            "babylon": {
+              "version": "6.18.0",
+              "bundled": true,
+              "dev": true
+            },
+            "balanced-match": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "base": {
+              "version": "0.11.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "cache-base": "1.0.1",
+                "class-utils": "0.3.6",
+                "component-emitter": "1.2.1",
+                "define-property": "1.0.0",
+                "isobject": "3.0.1",
+                "mixin-deep": "1.3.1",
+                "pascalcase": "0.1.1"
+              },
+              "dependencies": {
+                "define-property": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "is-descriptor": "1.0.2"
+                  }
+                },
+                "isobject": {
+                  "version": "3.0.1",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "brace-expansion": {
+              "version": "1.1.11",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "balanced-match": "1.0.0",
+                "concat-map": "0.0.1"
+              }
+            },
+            "braces": {
+              "version": "1.8.5",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "expand-range": "1.8.2",
+                "preserve": "0.2.0",
+                "repeat-element": "1.1.2"
+              }
+            },
+            "builtin-modules": {
+              "version": "1.1.1",
+              "bundled": true,
+              "dev": true
+            },
+            "cache-base": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "collection-visit": "1.0.0",
+                "component-emitter": "1.2.1",
+                "get-value": "2.0.6",
+                "has-value": "1.0.0",
+                "isobject": "3.0.1",
+                "set-value": "2.0.0",
+                "to-object-path": "0.3.0",
+                "union-value": "1.0.0",
+                "unset-value": "1.0.0"
+              },
+              "dependencies": {
+                "isobject": {
+                  "version": "3.0.1",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "caching-transform": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "md5-hex": "1.3.0",
+                "mkdirp": "0.5.1",
+                "write-file-atomic": "1.3.4"
+              }
+            },
+            "camelcase": {
+              "version": "1.2.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "center-align": {
+              "version": "0.1.3",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "align-text": "0.1.4",
+                "lazy-cache": "1.0.4"
+              }
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ansi-styles": "2.2.1",
+                "escape-string-regexp": "1.0.5",
+                "has-ansi": "2.0.0",
+                "strip-ansi": "3.0.1",
+                "supports-color": "2.0.0"
+              }
+            },
+            "class-utils": {
+              "version": "0.3.6",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "arr-union": "3.1.0",
+                "define-property": "0.2.5",
+                "isobject": "3.0.1",
+                "static-extend": "0.1.2"
+              },
+              "dependencies": {
+                "define-property": {
+                  "version": "0.2.5",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "is-descriptor": "0.1.6"
+                  }
+                },
+                "is-accessor-descriptor": {
+                  "version": "0.1.6",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "kind-of": "3.2.2"
+                  },
+                  "dependencies": {
+                    "kind-of": {
+                      "version": "3.2.2",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "is-buffer": "1.1.6"
+                      }
+                    }
+                  }
+                },
+                "is-data-descriptor": {
+                  "version": "0.1.4",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "kind-of": "3.2.2"
+                  },
+                  "dependencies": {
+                    "kind-of": {
+                      "version": "3.2.2",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "is-buffer": "1.1.6"
+                      }
+                    }
+                  }
+                },
+                "is-descriptor": {
+                  "version": "0.1.6",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "is-accessor-descriptor": "0.1.6",
+                    "is-data-descriptor": "0.1.4",
+                    "kind-of": "5.1.0"
+                  }
+                },
+                "isobject": {
+                  "version": "3.0.1",
+                  "bundled": true,
+                  "dev": true
+                },
+                "kind-of": {
+                  "version": "5.1.0",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "cliui": {
+              "version": "2.1.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "center-align": "0.1.3",
+                "right-align": "0.1.3",
+                "wordwrap": "0.0.2"
+              },
+              "dependencies": {
+                "wordwrap": {
+                  "version": "0.0.2",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                }
+              }
+            },
+            "code-point-at": {
+              "version": "1.1.0",
+              "bundled": true,
+              "dev": true
+            },
+            "collection-visit": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "map-visit": "1.0.0",
+                "object-visit": "1.0.1"
+              }
+            },
+            "commondir": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "component-emitter": {
+              "version": "1.2.1",
+              "bundled": true,
+              "dev": true
+            },
+            "concat-map": {
+              "version": "0.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "convert-source-map": {
+              "version": "1.5.1",
+              "bundled": true,
+              "dev": true
+            },
+            "copy-descriptor": {
+              "version": "0.1.1",
+              "bundled": true,
+              "dev": true
+            },
+            "core-js": {
+              "version": "2.5.3",
+              "bundled": true,
+              "dev": true
+            },
+            "cross-spawn": {
+              "version": "4.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "lru-cache": "4.1.2",
+                "which": "1.3.0"
+              }
+            },
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "debug-log": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "decamelize": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true
+            },
+            "decode-uri-component": {
+              "version": "0.2.0",
+              "bundled": true,
+              "dev": true
+            },
+            "default-require-extensions": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "strip-bom": "2.0.0"
+              }
+            },
+            "define-property": {
+              "version": "2.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-descriptor": "1.0.2",
+                "isobject": "3.0.1"
+              },
+              "dependencies": {
+                "isobject": {
+                  "version": "3.0.1",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "detect-indent": {
+              "version": "4.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "repeating": "2.0.1"
+              }
+            },
+            "error-ex": {
+              "version": "1.3.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-arrayish": "0.2.1"
+              }
+            },
+            "escape-string-regexp": {
+              "version": "1.0.5",
+              "bundled": true,
+              "dev": true
+            },
+            "esutils": {
+              "version": "2.0.2",
+              "bundled": true,
+              "dev": true
+            },
+            "execa": {
+              "version": "0.7.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "cross-spawn": "5.1.0",
+                "get-stream": "3.0.0",
+                "is-stream": "1.1.0",
+                "npm-run-path": "2.0.2",
+                "p-finally": "1.0.0",
+                "signal-exit": "3.0.2",
+                "strip-eof": "1.0.0"
+              },
+              "dependencies": {
+                "cross-spawn": {
+                  "version": "5.1.0",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "lru-cache": "4.1.2",
+                    "shebang-command": "1.2.0",
+                    "which": "1.3.0"
+                  }
+                }
+              }
+            },
+            "expand-brackets": {
+              "version": "0.1.5",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-posix-bracket": "0.1.1"
+              }
+            },
+            "expand-range": {
+              "version": "1.8.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "fill-range": "2.2.3"
+              }
+            },
+            "extend-shallow": {
+              "version": "3.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "assign-symbols": "1.0.0",
+                "is-extendable": "1.0.1"
+              },
+              "dependencies": {
+                "is-extendable": {
+                  "version": "1.0.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "is-plain-object": "2.0.4"
+                  }
+                }
+              }
+            },
+            "extglob": {
+              "version": "0.3.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-extglob": "1.0.0"
+              }
+            },
+            "filename-regex": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "fill-range": {
+              "version": "2.2.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-number": "2.1.0",
+                "isobject": "2.1.0",
+                "randomatic": "1.1.7",
+                "repeat-element": "1.1.2",
+                "repeat-string": "1.6.1"
+              }
+            },
+            "find-cache-dir": {
+              "version": "0.1.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "commondir": "1.0.1",
+                "mkdirp": "0.5.1",
+                "pkg-dir": "1.0.0"
+              }
+            },
+            "find-up": {
+              "version": "2.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "locate-path": "2.0.0"
+              }
+            },
+            "for-in": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true
+            },
+            "for-own": {
+              "version": "0.1.5",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "for-in": "1.0.2"
+              }
+            },
+            "foreground-child": {
+              "version": "1.5.6",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "cross-spawn": "4.0.2",
+                "signal-exit": "3.0.2"
+              }
+            },
+            "fragment-cache": {
+              "version": "0.2.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "map-cache": "0.2.2"
+              }
+            },
+            "fs.realpath": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "get-caller-file": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true
+            },
+            "get-stream": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "get-value": {
+              "version": "2.0.6",
+              "bundled": true,
+              "dev": true
+            },
+            "glob": {
+              "version": "7.1.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "fs.realpath": "1.0.0",
+                "inflight": "1.0.6",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.1"
+              }
+            },
+            "glob-base": {
+              "version": "0.3.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "glob-parent": "2.0.0",
+                "is-glob": "2.0.1"
+              }
+            },
+            "glob-parent": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-glob": "2.0.1"
+              }
+            },
+            "globals": {
+              "version": "9.18.0",
+              "bundled": true,
+              "dev": true
+            },
+            "graceful-fs": {
+              "version": "4.1.11",
+              "bundled": true,
+              "dev": true
+            },
+            "handlebars": {
+              "version": "4.0.11",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "async": "1.5.2",
+                "optimist": "0.6.1",
+                "source-map": "0.4.4",
+                "uglify-js": "2.8.29"
+              },
+              "dependencies": {
+                "source-map": {
+                  "version": "0.4.4",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "amdefine": "1.0.1"
+                  }
+                }
+              }
+            },
+            "has-ansi": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ansi-regex": "2.1.1"
+              }
+            },
+            "has-flag": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "has-value": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "get-value": "2.0.6",
+                "has-values": "1.0.0",
+                "isobject": "3.0.1"
+              },
+              "dependencies": {
+                "isobject": {
+                  "version": "3.0.1",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "has-values": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-number": "3.0.0",
+                "kind-of": "4.0.0"
+              },
+              "dependencies": {
+                "is-number": {
+                  "version": "3.0.0",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "kind-of": "3.2.2"
+                  },
+                  "dependencies": {
+                    "kind-of": {
+                      "version": "3.2.2",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "is-buffer": "1.1.6"
+                      }
+                    }
+                  }
+                },
+                "kind-of": {
+                  "version": "4.0.0",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "1.1.6"
+                  }
+                }
+              }
+            },
+            "hosted-git-info": {
+              "version": "2.6.0",
+              "bundled": true,
+              "dev": true
+            },
+            "imurmurhash": {
+              "version": "0.1.4",
+              "bundled": true,
+              "dev": true
+            },
+            "inflight": {
+              "version": "1.0.6",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "once": "1.4.0",
+                "wrappy": "1.0.2"
+              }
+            },
+            "inherits": {
+              "version": "2.0.3",
+              "bundled": true,
+              "dev": true
+            },
+            "invariant": {
+              "version": "2.2.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "loose-envify": "1.3.1"
+              }
+            },
+            "invert-kv": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "kind-of": "6.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "6.0.2",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "is-arrayish": {
+              "version": "0.2.1",
+              "bundled": true,
+              "dev": true
+            },
+            "is-buffer": {
+              "version": "1.1.6",
+              "bundled": true,
+              "dev": true
+            },
+            "is-builtin-module": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "builtin-modules": "1.1.1"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "kind-of": "6.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "6.0.2",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "1.0.0",
+                "is-data-descriptor": "1.0.0",
+                "kind-of": "6.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "6.0.2",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "is-dotfile": {
+              "version": "1.0.3",
+              "bundled": true,
+              "dev": true
+            },
+            "is-equal-shallow": {
+              "version": "0.1.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-primitive": "2.0.0"
+              }
+            },
+            "is-extendable": {
+              "version": "0.1.1",
+              "bundled": true,
+              "dev": true
+            },
+            "is-extglob": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "is-finite": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "number-is-nan": "1.0.1"
+              }
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "is-glob": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-extglob": "1.0.0"
+              }
+            },
+            "is-number": {
+              "version": "2.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "kind-of": "3.2.2"
+              }
+            },
+            "is-odd": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-number": "4.0.0"
+              },
+              "dependencies": {
+                "is-number": {
+                  "version": "4.0.0",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "is-plain-object": {
+              "version": "2.0.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "isobject": "3.0.1"
+              },
+              "dependencies": {
+                "isobject": {
+                  "version": "3.0.1",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "is-posix-bracket": {
+              "version": "0.1.1",
+              "bundled": true,
+              "dev": true
+            },
+            "is-primitive": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "is-stream": {
+              "version": "1.1.0",
+              "bundled": true,
+              "dev": true
+            },
+            "is-utf8": {
+              "version": "0.2.1",
+              "bundled": true,
+              "dev": true
+            },
+            "is-windows": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "isexe": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "isobject": {
+              "version": "2.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "isarray": "1.0.0"
+              }
+            },
+            "istanbul-lib-coverage": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true
+            },
+            "istanbul-lib-hook": {
+              "version": "1.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "append-transform": "0.4.0"
+              }
+            },
+            "istanbul-lib-instrument": {
+              "version": "1.10.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "babel-generator": "6.26.1",
+                "babel-template": "6.26.0",
+                "babel-traverse": "6.26.0",
+                "babel-types": "6.26.0",
+                "babylon": "6.18.0",
+                "istanbul-lib-coverage": "1.2.0",
+                "semver": "5.5.0"
+              }
+            },
+            "istanbul-lib-report": {
+              "version": "1.1.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "istanbul-lib-coverage": "1.2.0",
+                "mkdirp": "0.5.1",
+                "path-parse": "1.0.5",
+                "supports-color": "3.2.3"
+              },
+              "dependencies": {
+                "supports-color": {
+                  "version": "3.2.3",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "has-flag": "1.0.0"
+                  }
+                }
+              }
+            },
+            "istanbul-lib-source-maps": {
+              "version": "1.2.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "debug": "3.1.0",
+                "istanbul-lib-coverage": "1.2.0",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.2",
+                "source-map": "0.5.7"
+              },
+              "dependencies": {
+                "debug": {
+                  "version": "3.1.0",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "ms": "2.0.0"
+                  }
+                }
+              }
+            },
+            "istanbul-reports": {
+              "version": "1.3.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "handlebars": "4.0.11"
+              }
+            },
+            "js-tokens": {
+              "version": "3.0.2",
+              "bundled": true,
+              "dev": true
+            },
+            "jsesc": {
+              "version": "1.3.0",
+              "bundled": true,
+              "dev": true
+            },
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            },
+            "lazy-cache": {
+              "version": "1.0.4",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "lcid": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "invert-kv": "1.0.0"
+              }
+            },
+            "load-json-file": {
+              "version": "1.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "graceful-fs": "4.1.11",
+                "parse-json": "2.2.0",
+                "pify": "2.3.0",
+                "pinkie-promise": "2.0.1",
+                "strip-bom": "2.0.0"
+              }
+            },
+            "locate-path": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "p-locate": "2.0.0",
+                "path-exists": "3.0.0"
+              },
+              "dependencies": {
+                "path-exists": {
+                  "version": "3.0.0",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "lodash": {
+              "version": "4.17.5",
+              "bundled": true,
+              "dev": true
+            },
+            "longest": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "loose-envify": {
+              "version": "1.3.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "js-tokens": "3.0.2"
+              }
+            },
+            "lru-cache": {
+              "version": "4.1.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "pseudomap": "1.0.2",
+                "yallist": "2.1.2"
+              }
+            },
+            "map-cache": {
+              "version": "0.2.2",
+              "bundled": true,
+              "dev": true
+            },
+            "map-visit": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "object-visit": "1.0.1"
+              }
+            },
+            "md5-hex": {
+              "version": "1.3.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "md5-o-matic": "0.1.1"
+              }
+            },
+            "md5-o-matic": {
+              "version": "0.1.1",
+              "bundled": true,
+              "dev": true
+            },
+            "mem": {
+              "version": "1.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "mimic-fn": "1.2.0"
+              }
+            },
+            "merge-source-map": {
+              "version": "1.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "source-map": "0.6.1"
+              },
+              "dependencies": {
+                "source-map": {
+                  "version": "0.6.1",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "micromatch": {
+              "version": "2.3.11",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "arr-diff": "2.0.0",
+                "array-unique": "0.2.1",
+                "braces": "1.8.5",
+                "expand-brackets": "0.1.5",
+                "extglob": "0.3.2",
+                "filename-regex": "2.0.1",
+                "is-extglob": "1.0.0",
+                "is-glob": "2.0.1",
+                "kind-of": "3.2.2",
+                "normalize-path": "2.1.1",
+                "object.omit": "2.0.1",
+                "parse-glob": "3.0.4",
+                "regex-cache": "0.4.4"
+              }
+            },
+            "mimic-fn": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "brace-expansion": "1.1.11"
+              }
+            },
+            "minimist": {
+              "version": "0.0.8",
+              "bundled": true,
+              "dev": true
+            },
+            "mixin-deep": {
+              "version": "1.3.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "for-in": "1.0.2",
+                "is-extendable": "1.0.1"
+              },
+              "dependencies": {
+                "is-extendable": {
+                  "version": "1.0.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "is-plain-object": "2.0.4"
+                  }
+                }
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "minimist": "0.0.8"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "nanomatch": {
+              "version": "1.2.9",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "arr-diff": "4.0.0",
+                "array-unique": "0.3.2",
+                "define-property": "2.0.2",
+                "extend-shallow": "3.0.2",
+                "fragment-cache": "0.2.1",
+                "is-odd": "2.0.0",
+                "is-windows": "1.0.2",
+                "kind-of": "6.0.2",
+                "object.pick": "1.3.0",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
+              },
+              "dependencies": {
+                "arr-diff": {
+                  "version": "4.0.0",
+                  "bundled": true,
+                  "dev": true
+                },
+                "array-unique": {
+                  "version": "0.3.2",
+                  "bundled": true,
+                  "dev": true
+                },
+                "kind-of": {
+                  "version": "6.0.2",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "normalize-package-data": {
+              "version": "2.4.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "hosted-git-info": "2.6.0",
+                "is-builtin-module": "1.0.0",
+                "semver": "5.5.0",
+                "validate-npm-package-license": "3.0.3"
+              }
+            },
+            "normalize-path": {
+              "version": "2.1.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "remove-trailing-separator": "1.1.0"
+              }
+            },
+            "npm-run-path": {
+              "version": "2.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "path-key": "2.0.1"
+              }
+            },
+            "number-is-nan": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "bundled": true,
+              "dev": true
+            },
+            "object-copy": {
+              "version": "0.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "copy-descriptor": "0.1.1",
+                "define-property": "0.2.5",
+                "kind-of": "3.2.2"
+              },
+              "dependencies": {
+                "define-property": {
+                  "version": "0.2.5",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "is-descriptor": "0.1.6"
+                  }
+                },
+                "is-accessor-descriptor": {
+                  "version": "0.1.6",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "kind-of": "3.2.2"
+                  }
+                },
+                "is-data-descriptor": {
+                  "version": "0.1.4",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "kind-of": "3.2.2"
+                  }
+                },
+                "is-descriptor": {
+                  "version": "0.1.6",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "is-accessor-descriptor": "0.1.6",
+                    "is-data-descriptor": "0.1.4",
+                    "kind-of": "5.1.0"
+                  },
+                  "dependencies": {
+                    "kind-of": {
+                      "version": "5.1.0",
+                      "bundled": true,
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "object-visit": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "isobject": "3.0.1"
+              },
+              "dependencies": {
+                "isobject": {
+                  "version": "3.0.1",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "object.omit": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "for-own": "0.1.5",
+                "is-extendable": "0.1.1"
+              }
+            },
+            "object.pick": {
+              "version": "1.3.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "isobject": "3.0.1"
+              },
+              "dependencies": {
+                "isobject": {
+                  "version": "3.0.1",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "once": {
+              "version": "1.4.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "wrappy": "1.0.2"
+              }
+            },
+            "optimist": {
+              "version": "0.6.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "minimist": "0.0.8",
+                "wordwrap": "0.0.3"
+              }
+            },
+            "os-homedir": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true
+            },
+            "os-locale": {
+              "version": "2.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "execa": "0.7.0",
+                "lcid": "1.0.0",
+                "mem": "1.1.0"
+              }
+            },
+            "p-finally": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "p-limit": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "p-try": "1.0.0"
+              }
+            },
+            "p-locate": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "p-limit": "1.2.0"
+              }
+            },
+            "p-try": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "parse-glob": {
+              "version": "3.0.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "glob-base": "0.3.0",
+                "is-dotfile": "1.0.3",
+                "is-extglob": "1.0.0",
+                "is-glob": "2.0.1"
+              }
+            },
+            "parse-json": {
+              "version": "2.2.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "error-ex": "1.3.1"
+              }
+            },
+            "pascalcase": {
+              "version": "0.1.1",
+              "bundled": true,
+              "dev": true
+            },
+            "path-exists": {
+              "version": "2.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "pinkie-promise": "2.0.1"
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "path-key": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "path-parse": {
+              "version": "1.0.5",
+              "bundled": true,
+              "dev": true
+            },
+            "path-type": {
+              "version": "1.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "graceful-fs": "4.1.11",
+                "pify": "2.3.0",
+                "pinkie-promise": "2.0.1"
+              }
+            },
+            "pify": {
+              "version": "2.3.0",
+              "bundled": true,
+              "dev": true
+            },
+            "pinkie": {
+              "version": "2.0.4",
+              "bundled": true,
+              "dev": true
+            },
+            "pinkie-promise": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "pinkie": "2.0.4"
+              }
+            },
+            "pkg-dir": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "find-up": "1.1.2"
+              },
+              "dependencies": {
+                "find-up": {
+                  "version": "1.1.2",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "path-exists": "2.1.0",
+                    "pinkie-promise": "2.0.1"
+                  }
+                }
+              }
+            },
+            "posix-character-classes": {
+              "version": "0.1.1",
+              "bundled": true,
+              "dev": true
+            },
+            "preserve": {
+              "version": "0.2.0",
+              "bundled": true,
+              "dev": true
+            },
+            "pseudomap": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true
+            },
+            "randomatic": {
+              "version": "1.1.7",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-number": "3.0.0",
+                "kind-of": "4.0.0"
+              },
+              "dependencies": {
+                "is-number": {
+                  "version": "3.0.0",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "kind-of": "3.2.2"
+                  },
+                  "dependencies": {
+                    "kind-of": {
+                      "version": "3.2.2",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "is-buffer": "1.1.6"
+                      }
+                    }
+                  }
+                },
+                "kind-of": {
+                  "version": "4.0.0",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "1.1.6"
+                  }
+                }
+              }
+            },
+            "read-pkg": {
+              "version": "1.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "load-json-file": "1.1.0",
+                "normalize-package-data": "2.4.0",
+                "path-type": "1.1.0"
+              }
+            },
+            "read-pkg-up": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "find-up": "1.1.2",
+                "read-pkg": "1.1.0"
+              },
+              "dependencies": {
+                "find-up": {
+                  "version": "1.1.2",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "path-exists": "2.1.0",
+                    "pinkie-promise": "2.0.1"
+                  }
+                }
+              }
+            },
+            "regenerator-runtime": {
+              "version": "0.11.1",
+              "bundled": true,
+              "dev": true
+            },
+            "regex-cache": {
+              "version": "0.4.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-equal-shallow": "0.1.3"
+              }
+            },
+            "regex-not": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "extend-shallow": "3.0.2",
+                "safe-regex": "1.1.0"
+              }
+            },
+            "remove-trailing-separator": {
+              "version": "1.1.0",
+              "bundled": true,
+              "dev": true
+            },
+            "repeat-element": {
+              "version": "1.1.2",
+              "bundled": true,
+              "dev": true
+            },
+            "repeat-string": {
+              "version": "1.6.1",
+              "bundled": true,
+              "dev": true
+            },
+            "repeating": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-finite": "1.0.2"
+              }
+            },
+            "require-directory": {
+              "version": "2.1.1",
+              "bundled": true,
+              "dev": true
+            },
+            "require-main-filename": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "resolve-from": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "resolve-url": {
+              "version": "0.2.1",
+              "bundled": true,
+              "dev": true
+            },
+            "ret": {
+              "version": "0.1.15",
+              "bundled": true,
+              "dev": true
+            },
+            "right-align": {
+              "version": "0.1.3",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "align-text": "0.1.4"
+              }
+            },
+            "rimraf": {
+              "version": "2.6.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "glob": "7.1.2"
+              }
+            },
+            "safe-regex": {
+              "version": "1.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ret": "0.1.15"
+              }
+            },
+            "semver": {
+              "version": "5.5.0",
+              "bundled": true,
+              "dev": true
+            },
+            "set-blocking": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "set-value": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "extend-shallow": "2.0.1",
+                "is-extendable": "0.1.1",
+                "is-plain-object": "2.0.4",
+                "split-string": "3.1.0"
+              },
+              "dependencies": {
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "is-extendable": "0.1.1"
+                  }
+                }
+              }
+            },
+            "shebang-command": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "shebang-regex": "1.0.0"
+              }
+            },
+            "shebang-regex": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "signal-exit": {
+              "version": "3.0.2",
+              "bundled": true,
+              "dev": true
+            },
+            "slide": {
+              "version": "1.1.6",
+              "bundled": true,
+              "dev": true
+            },
+            "snapdragon": {
+              "version": "0.8.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "base": "0.11.2",
+                "debug": "2.6.9",
+                "define-property": "0.2.5",
+                "extend-shallow": "2.0.1",
+                "map-cache": "0.2.2",
+                "source-map": "0.5.7",
+                "source-map-resolve": "0.5.1",
+                "use": "3.1.0"
+              },
+              "dependencies": {
+                "define-property": {
+                  "version": "0.2.5",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "is-descriptor": "0.1.6"
+                  }
+                },
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "is-extendable": "0.1.1"
+                  }
+                },
+                "is-accessor-descriptor": {
+                  "version": "0.1.6",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "kind-of": "3.2.2"
+                  },
+                  "dependencies": {
+                    "kind-of": {
+                      "version": "3.2.2",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "is-buffer": "1.1.6"
+                      }
+                    }
+                  }
+                },
+                "is-data-descriptor": {
+                  "version": "0.1.4",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "kind-of": "3.2.2"
+                  },
+                  "dependencies": {
+                    "kind-of": {
+                      "version": "3.2.2",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "is-buffer": "1.1.6"
+                      }
+                    }
+                  }
+                },
+                "is-descriptor": {
+                  "version": "0.1.6",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "is-accessor-descriptor": "0.1.6",
+                    "is-data-descriptor": "0.1.4",
+                    "kind-of": "5.1.0"
+                  }
+                },
+                "kind-of": {
+                  "version": "5.1.0",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "snapdragon-node": {
+              "version": "2.1.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "define-property": "1.0.0",
+                "isobject": "3.0.1",
+                "snapdragon-util": "3.0.1"
+              },
+              "dependencies": {
+                "define-property": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "is-descriptor": "1.0.2"
+                  }
+                },
+                "isobject": {
+                  "version": "3.0.1",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "snapdragon-util": {
+              "version": "3.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "kind-of": "3.2.2"
+              }
+            },
+            "source-map": {
+              "version": "0.5.7",
+              "bundled": true,
+              "dev": true
+            },
+            "source-map-resolve": {
+              "version": "0.5.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "atob": "2.0.3",
+                "decode-uri-component": "0.2.0",
+                "resolve-url": "0.2.1",
+                "source-map-url": "0.4.0",
+                "urix": "0.1.0"
+              }
+            },
+            "source-map-url": {
+              "version": "0.4.0",
+              "bundled": true,
+              "dev": true
+            },
+            "spawn-wrap": {
+              "version": "1.4.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "foreground-child": "1.5.6",
+                "mkdirp": "0.5.1",
+                "os-homedir": "1.0.2",
+                "rimraf": "2.6.2",
+                "signal-exit": "3.0.2",
+                "which": "1.3.0"
+              }
+            },
+            "spdx-correct": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "spdx-expression-parse": "3.0.0",
+                "spdx-license-ids": "3.0.0"
+              }
+            },
+            "spdx-exceptions": {
+              "version": "2.1.0",
+              "bundled": true,
+              "dev": true
+            },
+            "spdx-expression-parse": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "spdx-exceptions": "2.1.0",
+                "spdx-license-ids": "3.0.0"
+              }
+            },
+            "spdx-license-ids": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "split-string": {
+              "version": "3.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "extend-shallow": "3.0.2"
+              }
+            },
+            "static-extend": {
+              "version": "0.1.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "define-property": "0.2.5",
+                "object-copy": "0.1.0"
+              },
+              "dependencies": {
+                "define-property": {
+                  "version": "0.2.5",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "is-descriptor": "0.1.6"
+                  }
+                },
+                "is-accessor-descriptor": {
+                  "version": "0.1.6",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "kind-of": "3.2.2"
+                  },
+                  "dependencies": {
+                    "kind-of": {
+                      "version": "3.2.2",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "is-buffer": "1.1.6"
+                      }
+                    }
+                  }
+                },
+                "is-data-descriptor": {
+                  "version": "0.1.4",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "kind-of": "3.2.2"
+                  },
+                  "dependencies": {
+                    "kind-of": {
+                      "version": "3.2.2",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "is-buffer": "1.1.6"
+                      }
+                    }
+                  }
+                },
+                "is-descriptor": {
+                  "version": "0.1.6",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "is-accessor-descriptor": "0.1.6",
+                    "is-data-descriptor": "0.1.4",
+                    "kind-of": "5.1.0"
+                  }
+                },
+                "kind-of": {
+                  "version": "5.1.0",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "string-width": {
+              "version": "2.1.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-fullwidth-code-point": "2.0.0",
+                "strip-ansi": "4.0.0"
+              },
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "3.0.0",
+                  "bundled": true,
+                  "dev": true
+                },
+                "strip-ansi": {
+                  "version": "4.0.0",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "ansi-regex": "3.0.0"
+                  }
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ansi-regex": "2.1.1"
+              }
+            },
+            "strip-bom": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-utf8": "0.2.1"
+              }
+            },
+            "strip-eof": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "test-exclude": {
+              "version": "4.2.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "arrify": "1.0.1",
+                "micromatch": "3.1.9",
+                "object-assign": "4.1.1",
+                "read-pkg-up": "1.0.1",
+                "require-main-filename": "1.0.1"
+              },
+              "dependencies": {
+                "arr-diff": {
+                  "version": "4.0.0",
+                  "bundled": true,
+                  "dev": true
+                },
+                "array-unique": {
+                  "version": "0.3.2",
+                  "bundled": true,
+                  "dev": true
+                },
+                "braces": {
+                  "version": "2.3.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "arr-flatten": "1.1.0",
+                    "array-unique": "0.3.2",
+                    "define-property": "1.0.0",
+                    "extend-shallow": "2.0.1",
+                    "fill-range": "4.0.0",
+                    "isobject": "3.0.1",
+                    "kind-of": "6.0.2",
+                    "repeat-element": "1.1.2",
+                    "snapdragon": "0.8.2",
+                    "snapdragon-node": "2.1.1",
+                    "split-string": "3.1.0",
+                    "to-regex": "3.0.2"
+                  },
+                  "dependencies": {
+                    "define-property": {
+                      "version": "1.0.0",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "is-descriptor": "1.0.2"
+                      }
+                    },
+                    "extend-shallow": {
+                      "version": "2.0.1",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "is-extendable": "0.1.1"
+                      }
+                    }
+                  }
+                },
+                "expand-brackets": {
+                  "version": "2.1.4",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "debug": "2.6.9",
+                    "define-property": "0.2.5",
+                    "extend-shallow": "2.0.1",
+                    "posix-character-classes": "0.1.1",
+                    "regex-not": "1.0.2",
+                    "snapdragon": "0.8.2",
+                    "to-regex": "3.0.2"
+                  },
+                  "dependencies": {
+                    "define-property": {
+                      "version": "0.2.5",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "is-descriptor": "0.1.6"
+                      }
+                    },
+                    "extend-shallow": {
+                      "version": "2.0.1",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "is-extendable": "0.1.1"
+                      }
+                    },
+                    "is-descriptor": {
+                      "version": "0.1.6",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "is-accessor-descriptor": "0.1.6",
+                        "is-data-descriptor": "0.1.4",
+                        "kind-of": "5.1.0"
+                      }
+                    },
+                    "kind-of": {
+                      "version": "5.1.0",
+                      "bundled": true,
+                      "dev": true
+                    }
+                  }
+                },
+                "extglob": {
+                  "version": "2.0.4",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "array-unique": "0.3.2",
+                    "define-property": "1.0.0",
+                    "expand-brackets": "2.1.4",
+                    "extend-shallow": "2.0.1",
+                    "fragment-cache": "0.2.1",
+                    "regex-not": "1.0.2",
+                    "snapdragon": "0.8.2",
+                    "to-regex": "3.0.2"
+                  },
+                  "dependencies": {
+                    "define-property": {
+                      "version": "1.0.0",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "is-descriptor": "1.0.2"
+                      }
+                    },
+                    "extend-shallow": {
+                      "version": "2.0.1",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "is-extendable": "0.1.1"
+                      }
+                    }
+                  }
+                },
+                "fill-range": {
+                  "version": "4.0.0",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "extend-shallow": "2.0.1",
+                    "is-number": "3.0.0",
+                    "repeat-string": "1.6.1",
+                    "to-regex-range": "2.1.1"
+                  },
+                  "dependencies": {
+                    "extend-shallow": {
+                      "version": "2.0.1",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "is-extendable": "0.1.1"
+                      }
+                    }
+                  }
+                },
+                "is-accessor-descriptor": {
+                  "version": "0.1.6",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "kind-of": "3.2.2"
+                  },
+                  "dependencies": {
+                    "kind-of": {
+                      "version": "3.2.2",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "is-buffer": "1.1.6"
+                      }
+                    }
+                  }
+                },
+                "is-data-descriptor": {
+                  "version": "0.1.4",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "kind-of": "3.2.2"
+                  },
+                  "dependencies": {
+                    "kind-of": {
+                      "version": "3.2.2",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "is-buffer": "1.1.6"
+                      }
+                    }
+                  }
+                },
+                "is-number": {
+                  "version": "3.0.0",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "kind-of": "3.2.2"
+                  },
+                  "dependencies": {
+                    "kind-of": {
+                      "version": "3.2.2",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "is-buffer": "1.1.6"
+                      }
+                    }
+                  }
+                },
+                "isobject": {
+                  "version": "3.0.1",
+                  "bundled": true,
+                  "dev": true
+                },
+                "kind-of": {
+                  "version": "6.0.2",
+                  "bundled": true,
+                  "dev": true
+                },
+                "micromatch": {
+                  "version": "3.1.9",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "arr-diff": "4.0.0",
+                    "array-unique": "0.3.2",
+                    "braces": "2.3.1",
+                    "define-property": "2.0.2",
+                    "extend-shallow": "3.0.2",
+                    "extglob": "2.0.4",
+                    "fragment-cache": "0.2.1",
+                    "kind-of": "6.0.2",
+                    "nanomatch": "1.2.9",
+                    "object.pick": "1.3.0",
+                    "regex-not": "1.0.2",
+                    "snapdragon": "0.8.2",
+                    "to-regex": "3.0.2"
+                  }
+                }
+              }
+            },
+            "to-fast-properties": {
+              "version": "1.0.3",
+              "bundled": true,
+              "dev": true
+            },
+            "to-object-path": {
+              "version": "0.3.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "kind-of": "3.2.2"
+              }
+            },
+            "to-regex": {
+              "version": "3.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "define-property": "2.0.2",
+                "extend-shallow": "3.0.2",
+                "regex-not": "1.0.2",
+                "safe-regex": "1.1.0"
+              }
+            },
+            "to-regex-range": {
+              "version": "2.1.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-number": "3.0.0",
+                "repeat-string": "1.6.1"
+              },
+              "dependencies": {
+                "is-number": {
+                  "version": "3.0.0",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "kind-of": "3.2.2"
+                  }
+                }
+              }
+            },
+            "trim-right": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "uglify-js": {
+              "version": "2.8.29",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "source-map": "0.5.7",
+                "uglify-to-browserify": "1.0.2",
+                "yargs": "3.10.0"
+              },
+              "dependencies": {
+                "yargs": {
+                  "version": "3.10.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "camelcase": "1.2.1",
+                    "cliui": "2.1.0",
+                    "decamelize": "1.2.0",
+                    "window-size": "0.1.0"
+                  }
+                }
+              }
+            },
+            "uglify-to-browserify": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "union-value": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "arr-union": "3.1.0",
+                "get-value": "2.0.6",
+                "is-extendable": "0.1.1",
+                "set-value": "0.4.3"
+              },
+              "dependencies": {
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "is-extendable": "0.1.1"
+                  }
+                },
+                "set-value": {
+                  "version": "0.4.3",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "extend-shallow": "2.0.1",
+                    "is-extendable": "0.1.1",
+                    "is-plain-object": "2.0.4",
+                    "to-object-path": "0.3.0"
+                  }
+                }
+              }
+            },
+            "unset-value": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "has-value": "0.3.1",
+                "isobject": "3.0.1"
+              },
+              "dependencies": {
+                "has-value": {
+                  "version": "0.3.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "get-value": "2.0.6",
+                    "has-values": "0.1.4",
+                    "isobject": "2.1.0"
+                  },
+                  "dependencies": {
+                    "isobject": {
+                      "version": "2.1.0",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "isarray": "1.0.0"
+                      }
+                    }
+                  }
+                },
+                "has-values": {
+                  "version": "0.1.4",
+                  "bundled": true,
+                  "dev": true
+                },
+                "isobject": {
+                  "version": "3.0.1",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "urix": {
+              "version": "0.1.0",
+              "bundled": true,
+              "dev": true
+            },
+            "use": {
+              "version": "3.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "kind-of": "6.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "6.0.2",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "validate-npm-package-license": {
+              "version": "3.0.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "spdx-correct": "3.0.0",
+                "spdx-expression-parse": "3.0.0"
+              }
+            },
+            "which": {
+              "version": "1.3.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "isexe": "2.0.0"
+              }
+            },
+            "which-module": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "window-size": {
+              "version": "0.1.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "wordwrap": {
+              "version": "0.0.3",
+              "bundled": true,
+              "dev": true
+            },
+            "wrap-ansi": {
+              "version": "2.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1"
+              },
+              "dependencies": {
+                "is-fullwidth-code-point": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "number-is-nan": "1.0.1"
+                  }
+                },
+                "string-width": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "code-point-at": "1.1.0",
+                    "is-fullwidth-code-point": "1.0.0",
+                    "strip-ansi": "3.0.1"
+                  }
+                }
+              }
+            },
+            "wrappy": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true
+            },
+            "write-file-atomic": {
+              "version": "1.3.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "graceful-fs": "4.1.11",
+                "imurmurhash": "0.1.4",
+                "slide": "1.1.6"
+              }
+            },
+            "y18n": {
+              "version": "3.2.1",
+              "bundled": true,
+              "dev": true
+            },
+            "yallist": {
+              "version": "2.1.2",
+              "bundled": true,
+              "dev": true
+            },
+            "yargs": {
+              "version": "11.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "cliui": "4.0.0",
+                "decamelize": "1.2.0",
+                "find-up": "2.1.0",
+                "get-caller-file": "1.0.2",
+                "os-locale": "2.1.0",
+                "require-directory": "2.1.1",
+                "require-main-filename": "1.0.1",
+                "set-blocking": "2.0.0",
+                "string-width": "2.1.1",
+                "which-module": "2.0.0",
+                "y18n": "3.2.1",
+                "yargs-parser": "9.0.2"
+              },
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "3.0.0",
+                  "bundled": true,
+                  "dev": true
+                },
+                "camelcase": {
+                  "version": "4.1.0",
+                  "bundled": true,
+                  "dev": true
+                },
+                "cliui": {
+                  "version": "4.0.0",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "string-width": "2.1.1",
+                    "strip-ansi": "4.0.0",
+                    "wrap-ansi": "2.1.0"
+                  }
+                },
+                "strip-ansi": {
+                  "version": "4.0.0",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "ansi-regex": "3.0.0"
+                  }
+                },
+                "yargs-parser": {
+                  "version": "9.0.2",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "camelcase": "4.1.0"
+                  }
+                }
+              }
+            },
+            "yargs-parser": {
+              "version": "8.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "camelcase": "4.1.0"
+              },
+              "dependencies": {
+                "camelcase": {
+                  "version": "4.1.0",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            }
           }
-        }
-      }
-    },
-    "tap-parser": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-5.4.0.tgz",
-      "integrity": "sha512-BIsIaGqv7uTQgTW1KLTMNPSEQf4zDDPgYOBRdgOfuB+JFOLRBfEu6cLa/KvMvmqggu1FKXDfitjLwsq4827RvA==",
-      "dev": true,
-      "requires": {
-        "events-to-array": "1.1.2",
-        "js-yaml": "3.10.0",
-        "readable-stream": "2.3.3"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+        },
+        "own-or-env": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/own-or-env/-/own-or-env-1.0.1.tgz",
+          "integrity": "sha512-y8qULRbRAlL6x2+M0vIe7jJbJx/kmUTzYonRAa2ayesR2qWLswninkVyeJe4x3IEXhdgoNodzjQRKAoEs6Fmrw==",
+          "dev": true,
+          "requires": {
+            "own-or": "1.0.0"
+          }
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "dev": true,
           "optional": true
         },
-        "js-yaml": {
-          "version": "3.10.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-          "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
-          "dev": true,
-          "requires": {
-            "argparse": "1.0.9",
-            "esprima": "4.0.0"
-          }
-        },
         "readable-stream": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "optional": true,
           "requires": {
             "core-util-is": "1.0.2",
             "inherits": "2.0.3",
             "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
+            "process-nextick-args": "2.0.0",
             "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
+            "string_decoder": "1.1.1",
             "util-deprecate": "1.0.2"
           }
         },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "source-map-support": {
+          "version": "0.5.4",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.4.tgz",
+          "integrity": "sha512-PETSPG6BjY1AHs2t64vS2aqAgu6dMIMXJULWFBGbh2Gr8nVLbCFDo6i/RMMvviIQ2h1Z8+5gQhVKSn2je9nmdg==",
+          "dev": true,
+          "requires": {
+            "source-map": "0.6.1"
+          }
+        },
         "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "optional": true,
           "requires": {
             "safe-buffer": "5.1.1"
+          }
+        },
+        "tap-mocha-reporter": {
+          "version": "3.0.7",
+          "resolved": "https://registry.npmjs.org/tap-mocha-reporter/-/tap-mocha-reporter-3.0.7.tgz",
+          "integrity": "sha512-GHVXJ38C3oPRpM3YUc43JlGdpVZYiKeT1fmAd3HH2+J+ZWwsNAUFvRRdoGsXLw9+gU9o+zXpBqhS/oXyRQYwlA==",
+          "dev": true,
+          "requires": {
+            "color-support": "1.1.3",
+            "debug": "2.6.9",
+            "diff": "1.4.0",
+            "escape-string-regexp": "1.0.5",
+            "glob": "7.1.2",
+            "js-yaml": "3.11.0",
+            "readable-stream": "2.3.6",
+            "tap-parser": "5.4.0",
+            "unicode-length": "1.0.3"
+          },
+          "dependencies": {
+            "tap-parser": {
+              "version": "5.4.0",
+              "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-5.4.0.tgz",
+              "integrity": "sha512-BIsIaGqv7uTQgTW1KLTMNPSEQf4zDDPgYOBRdgOfuB+JFOLRBfEu6cLa/KvMvmqggu1FKXDfitjLwsq4827RvA==",
+              "dev": true,
+              "requires": {
+                "events-to-array": "1.1.2",
+                "js-yaml": "3.11.0",
+                "readable-stream": "2.3.6"
+              }
+            }
+          }
+        },
+        "tap-parser": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-7.0.0.tgz",
+          "integrity": "sha512-05G8/LrzqOOFvZhhAk32wsGiPZ1lfUrl+iV7+OkKgfofZxiceZWMHkKmow71YsyVQ8IvGBP2EjcIjE5gL4l5lA==",
+          "dev": true,
+          "requires": {
+            "events-to-array": "1.1.2",
+            "js-yaml": "3.11.0",
+            "minipass": "2.2.4"
           }
         }
       }
@@ -7051,7 +7956,7 @@
     "tar-stream": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.5.tgz",
-      "integrity": "sha512-mQdgLPc/Vjfr3VWqWbfxW8yQNiJCbAZ+Gf6GDu1Cy0bdb33ofyiNGBtAY96jHFhDuivCwgW1H9DgTON+INiXgg==",
+      "integrity": "sha1-XK2Ed59FyDsfJQjZawnYjHIYr1U=",
       "dev": true,
       "requires": {
         "bl": "1.2.1",
@@ -7069,7 +7974,7 @@
         "readable-stream": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+          "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
           "dev": true,
           "requires": {
             "core-util-is": "1.0.2",
@@ -7084,7 +7989,7 @@
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
           "dev": true,
           "requires": {
             "safe-buffer": "5.1.1"
@@ -7164,32 +8069,20 @@
       "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
       "dev": true
     },
-    "timespan": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/timespan/-/timespan-2.3.0.tgz",
-      "integrity": "sha1-SQLOBAvRPYRcj1myfp1ZutbzmSk=",
-      "dev": true
-    },
     "tmatch": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/tmatch/-/tmatch-3.1.0.tgz",
-      "integrity": "sha512-W3MSATOCN4pVu2qFxmJLIArSifeSOFqnfx9hiUaVgOmeRoI2NbU7RNga+6G+L8ojlFeQge+ZPCclWyUpQ8UeNQ==",
+      "integrity": "sha1-cBJk/XWC0BRKgMha8zWMyiacceM=",
       "dev": true
     },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "integrity": "sha1-bTQzWIl2jSGyvNoKonfO07G/rfk=",
       "dev": true,
       "requires": {
         "os-tmpdir": "1.0.2"
       }
-    },
-    "tmpl": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
-      "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
-      "dev": true
     },
     "tough-cookie": {
       "version": "2.3.3",
@@ -7223,7 +8116,7 @@
     "tsame": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/tsame/-/tsame-1.1.2.tgz",
-      "integrity": "sha512-ovCs24PGjmByVPr9tSIOs/yjUX9sJl0grEmOsj9dZA/UknQkgPOKcUqM84aSCvt9awHuhc/boMzTg3BHFalxWw==",
+      "integrity": "sha1-XOAAKs9oWUJ4nGMBh5eiql5rA8U=",
       "dev": true
     },
     "tunnel-agent": {
@@ -7259,12 +8152,6 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-      "dev": true
-    },
-    "uglify-js": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.3.5.tgz",
-      "integrity": "sha1-S1v/+Rhu/7qoiOTJ6UvZ/EyUkp0=",
       "dev": true
     },
     "unicode-length": {
@@ -7432,7 +8319,7 @@
     "uuid": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
+      "integrity": "sha1-EsUou51Y0LkmXZovbw/ovhf/HxQ="
     },
     "validate-npm-package-license": {
       "version": "3.0.1",
@@ -7447,7 +8334,7 @@
     "validator": {
       "version": "9.1.2",
       "resolved": "https://registry.npmjs.org/validator/-/validator-9.1.2.tgz",
-      "integrity": "sha512-1Tml6crNdsSC61jHssWksQxq6C7MmSFCCmf99Eb+l/V/cwVlw4/Pg3YXBP1WKcHLsyqe3E+iJXUZgoTTQFcqQg==",
+      "integrity": "sha1-VxG2QT94vZ1WADEwyBtHw56GVGw=",
       "dev": true
     },
     "verror": {
@@ -7458,15 +8345,6 @@
         "assert-plus": "1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "1.3.0"
-      }
-    },
-    "walker": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
-      "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
-      "dev": true,
-      "requires": {
-        "makeerror": "1.0.11"
       }
     },
     "wdio-dot-reporter": {
@@ -7553,7 +8431,7 @@
         "supports-color": {
           "version": "5.0.1",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.0.1.tgz",
-          "integrity": "sha512-7FQGOlSQ+AQxBNXJpVDj8efTA/FtyB5wcNE1omXXJ0cq6jm1jjDwuROlYDbnzHqdNPqliWFhcioCWSyav+xBnA==",
+          "integrity": "sha1-HFMx8iJQyEICgFsvF63xZpnzo5o=",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -7570,7 +8448,7 @@
     "which": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+      "integrity": "sha1-/wS9/AEO5UfXgL7DjhrBwnd9JTo=",
       "dev": true,
       "requires": {
         "isexe": "2.0.0"
@@ -7624,20 +8502,6 @@
         }
       }
     },
-    "winston": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.0.tgz",
-      "integrity": "sha1-gIBQuT1SZh7Z+2wms/DIJnCLCu4=",
-      "dev": true,
-      "requires": {
-        "async": "1.0.0",
-        "colors": "1.0.3",
-        "cycle": "1.0.3",
-        "eyes": "0.1.8",
-        "isstream": "0.1.2",
-        "stack-trace": "0.0.10"
-      }
-    },
     "wordwrap": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
@@ -7658,12 +8522,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-    },
-    "wrench": {
-      "version": "1.3.9",
-      "resolved": "https://registry.npmjs.org/wrench/-/wrench-1.3.9.tgz",
-      "integrity": "sha1-bxPsNRRTF+spLKX2UxORskQRFBE=",
-      "dev": true
     },
     "write": {
       "version": "0.2.1",
@@ -7852,7 +8710,7 @@
         "readable-stream": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+          "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
           "dev": true,
           "requires": {
             "core-util-is": "1.0.2",
@@ -7867,7 +8725,7 @@
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
           "dev": true,
           "requires": {
             "safe-buffer": "5.1.1"

--- a/package.json
+++ b/package.json
@@ -84,11 +84,11 @@
     "electron-builder": "^20.2.0",
     "electron-debug": "^1.4.0",
     "image-size": "^0.6.1",
-    "sinon": "^3.2.0",
+    "sinon": "^4.5.0",
     "snazzy": "^7.0.0",
     "spectron": "^3.7.2",
     "standard": "^10.0.3",
-    "tap": "^10.7.2"
+    "tap": "^11.1.3"
   },
   "engines": {
     "node": ">=6.0.0"

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
   "devDependencies": {
     "cross-env": "^5.1.4",
     "devtron": "^1.4.0",
-    "electron": "^1.7.9",
+    "electron": "^1.8.4",
     "electron-builder": "^20.2.0",
     "electron-debug": "^1.4.0",
     "image-size": "^0.6.1",


### PR DESCRIPTION
Supesedes https://github.com/plotly/image-exporter/pull/69 after I figured out the best way to _clear_ the CI `node_modules` cache (see https://github.com/plotly/image-exporter/pull/69 if that ever happens to you).