### PR TITLE
Prepare readme for inital release etienne

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,151 @@
+# Contributing to @plotly/image-exporter
+
+Note that this section targets contributors. If you're interested in using the
+standalone app, [download the latest
+release.](https://github.com/plotly/image-exporter/releases).
+
+## Dev Installation
+
+### Prerequisites
+
+- git
+- [Node.js](https://nodejs.org/en/). We recommend using Node.js v8.x, but all
+  versions starting from v4 should work.  Upgrading and managing node versions
+  can be easily done using [`nvm`](https://github.com/creationix/nvm) or its
+  Windows alternatives.
+- [`npm`](https://www.npmjs.com/) v5.x and up (which ships by default with
+  Node.js v8.x) to ensure that the
+  [`package-lock.json`](https://docs.npmjs.com/files/package-lock.json) file is
+  used and updated correctly.
+
+### Clone the plotly.js repo
+
+```bash
+git clone https://github.com/plotly/plotly.js.git
+cd plotly.js
+```
+
+### Install Node.js dependencies
+
+```
+npm install
+```
+
+### Install poppler
+
+We haven't found a Node.js library that converts PDF files to EPS,
+so we use `poppler`:
+
+On Debian-flavored Linux:
+
+```
+apt-get poppler-utils
+```
+
+On OS X:
+
+```
+brew install poppler
+```
+
+On Windows:
+
+_Can anyone help us out?_
+
+
+## Running tests
+
+```
+npm test
+
+# or more granularly:
+
+# just the standard linter
+npm run test:lint
+
+# just the unit tests (TAP tests using Node.js only)
+npm run test:unit
+
+# just the integration tests (using spectron)
+npm run test:integration
+```
+
+## Packaging
+
+We use (`electron-builder`](https://github.com/electron-userland/electron-builder) to pack up
+the `plotly-graph-exporter` executable. To do so locally, run:
+
+```
+npm run pack
+```
+
+## Releases
+
+_to do_
+
+## Overview
+
+### Writing testable code for Electron Apps
+
+Electron creates an executable environment. That is, `require('electron')`
+does not do the same when executed as `node index.js` and `electron
+index.js`.
+
+So, to write good unit tests, it becomes important to split logic that only
+runs in Electron from other things that can be run in Node.js. That's why in
+`src/app/*`, only `index.js` requires Electron modules. The other modules are
+_pure_ Node.js and are tested in `test/unit/` using
+[TAP](http://www.node-tap.org/). The Electron logic is itself tested using
+[Spectron](https://github.com/electron/spectron) which is much slower.
+
+### Anatomy of an image-exporter component
+
+Along with a `name` field, each component has a `ping`, an `inject`, a `parse`,
+a `render` and a `convert` method:
+
+* `ping` (render process): method that send healthy signal renderer to main process
+* `inject` (optional, main process): returns a string or an array of strings
+  which is injected in the head of the app's HTML index file (e.g `<script
+  src="plotly.js"></script>`)
+* `parse` (required, main process): takes in a request body and coerces its
+  options
+* `render` (required, renderer process): takes options and returns image data
+* `convert` (required, main process): converts image data to output head and
+  body
+
+Component modules are _just_ plain objects, listing methods. Components aren't
+instantiated, their methods shouldn't depend on any `this`. We chose to not
+turn components into classes as this practice would be difficult to implement in the
+main and renderer process at once.
+
+### Nomenclature for IPC callbacks
+
+Image exporter is a heavy user of Electron's IPC (inter-process-communication)
+which is in turn callback heavy. To help us stay out of _callback hell_, we use
+the following terms to designates callbacks:
+
+- At the end of the data-parse callback, we call the component module `parse`
+  method as `parse(body, componentOpts, sendToRenderer)` where `sendToRenderer`
+  is callback.
+- `sendToRenderer` is the callback that transfers info from the main to the
+  renderer process as `sendToRenderer(errorCode, parseInfo)`.
+- In the renderer process we then call the component module `render` method as
+  `render(info, componentOpts, sendToMain)` where `sendToMain` is a callback.
+- `sendToMain` transfers info from the renderer back to main process as
+  `sendToMain(errorCode, result)`
+- Back in the main process, the component module `convert` method is then
+  called as `convert(fullInfo, componentOpts, reply)` when `reply` is (you
+  guessed it) a callback.
+- `reply` is then called as `reply(errorCode, convertInfo)`.
+
+### What happened to `nw.js`?
+
+Older plotly devs might remember our old `nw.js` image server, but yeah
+Electron is way better than `nw.js` a lot of people are using it. Using it for
+this project was a no-brainier.
+
+Devs more experienced with `nw.js` should note: Electron apps juggle between a
+Node.js process (called the **main** process) and browser scripts (call the
+**renderer** process). Compared to `nw.js`, creating Electron apps requires a
+little more boiler plate, but Electron makes it much easier to know what
+globals you have available.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,7 +72,7 @@ npm run test:integration
 
 ## Packaging
 
-We use (`electron-builder`](https://github.com/electron-userland/electron-builder) to pack up
+We use [`electron-builder`](https://github.com/electron-userland/electron-builder) to pack up
 the `plotly-graph-exporter` executable. To do so locally, run:
 
 ```
@@ -103,7 +103,8 @@ _pure_ Node.js and are tested in `test/unit/` using
 Along with a `name` field, each component has a `ping`, an `inject`, a `parse`,
 a `render` and a `convert` method:
 
-* `ping` (render process): method that send healthy signal renderer to main process
+* `ping` (required, renderer process): method that send healthy signal renderer
+  to main process
 * `inject` (optional, main process): returns a string or an array of strings
   which is injected in the head of the app's HTML index file (e.g `<script
   src="plotly.js"></script>`)
@@ -121,13 +122,13 @@ main and renderer process at once.
 ### Nomenclature for IPC callbacks
 
 Image exporter is a heavy user of Electron's IPC (inter-process-communication)
-which is in turn callback heavy. To help us stay out of _callback hell_, we use
+which in turn is callback heavy. To help us stay out of _callback hell_, we use
 the following terms to designates callbacks:
 
 - At the end of the data-parse callback, we call the component module `parse`
   method as `parse(body, componentOpts, sendToRenderer)` where `sendToRenderer`
-  is callback.
-- `sendToRenderer` is the callback that transfers info from the main to the
+  is a callback.
+- `sendToRenderer` transfers info from the main to the
   renderer process as `sendToRenderer(errorCode, parseInfo)`.
 - In the renderer process we then call the component module `render` method as
   `render(info, componentOpts, sendToMain)` where `sendToMain` is a callback.
@@ -141,8 +142,8 @@ the following terms to designates callbacks:
 ### What happened to `nw.js`?
 
 Older plotly devs might remember our old `nw.js` image server, but yeah
-Electron is way better than `nw.js` a lot of people are using it. Using it for
-this project was a no-brainier.
+Electron is way better than `nw.js` and a lot more people are using it. Using
+it for this project was a no-brainier.
 
 Devs more experienced with `nw.js` should note: Electron apps juggle between a
 Node.js process (called the **main** process) and browser scripts (call the

--- a/README.md
+++ b/README.md
@@ -166,10 +166,6 @@ Dispatch to one component based on the URL of the request:
 
 `curl localhost:9090/plotly-dashboard/ <payload>`
 
-### Pixel Comparisons
-
-This is similar to the current plotly.js pixel comparison runner, but as a standalone version that our R, Python, and Julia libraries could also use for testing purposes.
-
 ## Other Useful Links
 
 Debugging:

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ The environment you're installing this into may require Poppler.
 
 This image exporter is not a completely new tool. Rather, it is comprised of much preexisting functionality which has been organized and isolated into a single canonical repository. Plotly Cloud, plotly.js and eventually the R, Python and Julia libraries will require it and optionally configure it for their needs.
 
-This Image Exporter suite consists broadly of two commandline tools:
-* The "image server," which renders graphs as specified by commandline arguments
-* The "image runner," which renders graphs as specified by files in the local filesystem
+This Image Exporter suite consists broadly of two tools:
+* The "image server," which renders graphs as specified by POST requests
+* The "image runner," which renders graphs as specified by commandline statements
 
 The image runner makes the suite easier to use for plotly.js testing and the R, Python and Julia libraries.
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Plotly Image Exporter
 
-[![circle ci](https://circleci.com/gh/plotly/image-exporter.png?&style=shield&circle-token=1f42a03b242bd969756fc3e53ede204af9b507c0)](https://circleci.com/gh/plotly/image-exporter)
+[![CircleCI](https://circleci.com/gh/plotly/image-exporter.svg?style=svg)](https://circleci.com/gh/plotly/image-exporter)
 
 This repo contains source code for:
 
 - `plotly-graph-exporter` standalone app,
-- @plotly/image-exporter npm package, and
+- `@plotly/image-exporter` npm package, and
 - Plotly's image server
 
 ## `plotly-graph-exporter` standalone app
@@ -79,7 +79,7 @@ generates an SVG from a plotly.js JSON hosted on [plot.ly](https://plot.ly/).
 In turn, the `plotly-export-server`executable work similarly to plotly's own
 image server where not only plotly.js graphs can be exported, but also plotly
 dashboards, thumbnails and dash reports (see full list
-[here](https://github.com/plotly/image-exporter/tree/master/src/component).
+[here](https://github.com/plotly/image-exporter/tree/master/src/component)).
 
 Boot up the server with:
 
@@ -103,6 +103,7 @@ listener/emitter).
 
 To create a _runner_ app:
 
+<details>
 ```js
 // main.js
 
@@ -125,9 +126,11 @@ app.on('renderer-error', () => {})
 ```
 
 then launch it with `electron main.js`
+</details>
 
 Or to create a _server_ app:
 
+<details>
 ```js
 // main.js
 
@@ -167,6 +170,7 @@ app.on('renderer-error', () => {})
 ```
 
 then launch it with `electron main.js`
+</details>
 
 ## Plotly's image server
 

--- a/README.md
+++ b/README.md
@@ -44,10 +44,6 @@ Each component has an `inject`, a `parse`, a `render` and a `convert` method:
 
 Component modules are _just_ plain objects, listing methods. Components aren't instantiated, their methods shouldn't depend on any `this`.
 
-### Logging
-
-Logging can be achieved by listening to `app` events and piping their info into a user-chosen logger package (e.g. `bunyan` for the Plotly Cloud image server).
-
 ## API
 
 We export two Electron app creator methods: `run`, `serve`. Both methods return an Electron `app` object (which is an event listener/emitter).
@@ -165,19 +161,6 @@ Dispatch to one component based on the URL of the request:
 …or e.g.:
 
 `curl localhost:9090/plotly-dashboard/ <payload>`
-
-## Other Useful Links
-
-Debugging:
-
-* https://github.com/electron/devtron
-* https://electron.atom.io/docs/api/app/#event-gpu-process-crashed
-
-Performance:
-
-* https://github.com/electron/asar
-* https://github.com/pixijs/pixi.js/issues/2233
-* https://github.com/pixijs/pixi.js/pull/2481/files
 
 ## Nomenclature
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ system(cmd)
 With Node.js (v6.x or v8.x) and npm installed:
 
 ```
-npm install -g electron @plotly/image-exporter
+$ npm install -g electron @plotly/image-exporter
 ```
 
 which installs two executables `plotly-graph-exporter` and `plotly-export-server`
@@ -103,7 +103,6 @@ listener/emitter).
 
 To create a _runner_ app:
 
-<details>
 ```js
 // main.js
 
@@ -126,11 +125,9 @@ app.on('renderer-error', () => {})
 ```
 
 then launch it with `electron main.js`
-</details>
 
 Or to create a _server_ app:
 
-<details>
 ```js
 // main.js
 
@@ -170,7 +167,6 @@ app.on('renderer-error', () => {})
 ```
 
 then launch it with `electron main.js`
-</details>
 
 ## Plotly's image server
 
@@ -186,13 +182,13 @@ The environment you're installing this into may require Poppler for EPS exports.
 #### Poppler Installation via Aptitude (used by some \*nix/BSD, e.g. Ubuntu)
 
 ```
-apt-get poppler-utils (requires `sudo` or root privileges)
+$ apt-get poppler-utils (requires `sudo` or root privileges)
 ```
 
 #### Poppler Installation via Homebrew (third-party package manager for Mac OS X)
 
 ```
-brew install poppler
+$ brew install poppler
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -1,79 +1,58 @@
-# image-exporter
-
-aka image server 2.0.
-
-See https://github.com/plotly/streambed/issues/9655 for info on the requirements.
+# Plotly Image Exporter
 
 ## Install
 
-- `npm i`
-- install `poppler`:
-    - Linux: `apt-get poppler-utils`
-    - OS X: `brew install poppler`
-- `npm test`
+### Dependencies
 
-## In brief
+The environment you're installing this into may require Poppler.
 
-The new image exporter will be in a repo of its own. Streambed, plotly.js and
-eventually the R, Python and Julia libraries will require it and optionally
-configure it for their needs.
+#### Poppler Installation via Aptitude (used by some \*nix/BSD, e.g. Ubuntu)
 
-Note that I don't want to call this project _image server 2.0_ because I also
-want to expose an image _runner_ that reads files from the file system instead
-of handling HTTP requests - which will make it easier to use for plotly.js
-testing and the R, Python and Julia libraries.
+`apt-get poppler-utils` (requires `sudo` or root privileges)
+
+#### Poppler Installation via Homebrew (third-party package manager for Mac OS X)
+
+`brew install poppler`
+
+## In Brief
+
+This image exporter is not a completely new tool. Rather, it is comprised of much preexisting functionality which has been organized and isolated into a single canonical repository. Streambed, plotly.js and eventually the R, Python and Julia libraries will require it and optionally configure it for their needs.
+
+This Image Exporter suite consists broadly of two commandline tools:
+* The "image server," which renders graphs as specified by commandline arguments
+* The "image runner," which renders graphs as specified by files in the local filesystem
+
+The image runner makes the suite easier to use for plotly.js testing and the R, Python and Julia libraries.
 
 ### Electron
 
-It's way better than `nw.js`, a lot of people are using it. Using it for this
-project is a no-brainier.
+It's way better than `nw.js`, a lot of people are using it. Using it for this project is a no-brainier.
 
-Electron apps juggle between a node.js process (called the **main** process) and
-browser scripts (call the **renderer** process). Compared to `nw.js`, creating
-electron apps requires a little more boiler plate, but electron makes it much
-easier to know what globals you have available.
+Electron apps juggle between a node.js process (called the **main** process) and browser scripts (call the **renderer** process). Compared to `nw.js`, creating Electron apps requires a little more boiler plate, but Electron makes it much easier to know what globals you have available.
 
-Electron creates an executable environment. That is, `require('electron')` does
-not do the same when executed as `node index.js` and `electron index.js`. So, to
-write good unit tests, it becomes important to split logic that only runs in
-electron from other things that can be run in node. That's why in `src/app/*`,
-only `index.js` requires electron modules. The other modules are _pure_
-node.js and are tested in `test/unit/` using [TAP](http://www.node-tap.org/).
-The electron logic is itself tested using
-[spectron](https://github.com/electron/spectron) which is much slower.
+Electron creates an executable environment. That is, `require('electron')` does not do the same when executed as `node index.js` and `electron index.js`. So, to write good unit tests, it becomes important to split logic that only runs in Electron from other things that can be run in Node.js. That's why in `src/app/*`, only `index.js` requires Electron modules. The other modules are _pure_ Node.js and are tested in `test/unit/` using [TAP](http://www.node-tap.org/). The Electron logic is itself tested using [Spectron](https://github.com/electron/spectron) which is much slower.
 
 ### Components
 
 This project has a larger scope than the current image server.
 
-We want to export not just plotly `"data"/"layout"`, but dashboard print and
-thumbnail views.  Eventually, we could even export plotly animations to gifs.
-Moreover, we probably want some export types to be open-source while others
-streambed-only. Therefore, this package defines a _component_ framework. See
-`src/component/` for two examples.
+We want to export not just Plotly `"data"/"layout"`, but dashboard, print and thumbnail views.  Eventually, we could even export Plotly animations to gifs. Moreover, we probably want some export types to be open-source while others Streambed-only. Therefore, this package defines a _component_ framework. See `src/component/` for two examples.
 
 Each component has an `inject`, a `parse`, a `render` and a `convert` method:
+* `inject` (optional, main process) returns a string or an array of strings which is injected in the head of the app's HTML index file (e.g `<script src="plotly.js"></script>`)
+* `parse` (required, main process) takes in a request body and coerces its options
+* `render` (required, renderer process) takes options and returns image data
+* `convert` (required, main process) converts image data to output head and body
 
-- `inject` (optional, main process) returns a string or an array of strings
-  which is injected in the head of the app's HTML index file
-  (e.g `<script src="plotly.js"></script>`)
-- `parse` (required, main process) takes in a request body and coerces its options.
-- `render` (required, renderer process) takes options and returns image data
-- `convert` (required, main process) converts image data to output head and body
-
-Component modules are _just_ plain objects, listing methods. Components aren't
-instantiated, their methods shouldn't depend on any `this`.
+Component modules are _just_ plain objects, listing methods. Components aren't instantiated, their methods shouldn't depend on any `this`.
 
 ### Logging
 
-I propose that this package won't assume anything logging related. Logging will
-be achieved by listening to `app` events and piping their info into a
-user-chosen logger package (e.g. `bunyan` for the streambed image server).
+I propose that this package won't assume anything logging-related. Logging will be achieved by listening to `app` events and piping their info into a user-chosen logger package (e.g. `bunyan` for the Streambed image server).
 
 ## API
 
-We export two electron app creator methods: `run`, `serve`. Both methods return
-an electron `app` object (which is an event listener/emitter).
+We export two Electron app creator methods: `run`, `serve`. Both methods return an Electron `app` object (which is an event listener/emitter).
 
 ### `run`
 
@@ -148,65 +127,63 @@ and launch it with `electron main.js`.
 
 See `./bin/`.
 
-### Graph exporter
+### Graph Exporter
 
-A specialised `runner` for plotly graphs:
+A specialized "runner" for Plotly graphs:
 
-```
+```sh
 plotly-graph-exporter 20.json https://plot.ly/~empet/14324.json --format svg
 ```
 
-where `20.json` is a local `"data"/"layout"` JSON file and
-`https://plot.ly/~empet/14324` is a JSON URL.
+where `20.json` is a local `"data"/"layout"` JSON file and `https://plot.ly/~empet/14324` is a JSON URL.
 
-I'm thinking the R, Python and Julia libraries could simply call
-`plotly-graph-exporter` to offer offline image generation to their users.
+I'm thinking the R, Python and Julia libraries could simply call `plotly-graph-exporter` to offer offline image generation to their users.
 
-### Export server
+### Export Server
 
-Export server very similar to the current image server but with support
-for multiple components:
+The Export Server very similar to the current image server but with support for multiple components:
 
-```
-plotly-image-server --port 9090
+`plotly-image-server --port 9090`
 
-# Dispatch to one component based on url of request
-curl localhost:9090/plotly-graph/ <payload>
+Dispatch to one component based on the URL of the request:
 
-# or e.g.
-curl localhost:9090/plotly-dashboard/ <payload>
-```
+`curl localhost:9090/plotly-graph/ <payload>`
 
-### Pixel comparisons
+…or e.g.:
 
-Similar to the current plotly.js pixel comparison runner, but as a standalone
-version that our R, Python, Julia libraries could use too for testing purposes.
+`curl localhost:9090/plotly-dashboard/ <payload>`
 
-## Other useful links
+### Pixel Comparisons
+
+Similar to the current plotly.js pixel comparison runner, but as a standalone version that our R, Python, Julia libraries could use too for testing purposes.
+
+## Other Useful Links
 
 Debugging:
 
-+ https://github.com/electron/devtron
-+ https://electron.atom.io/docs/api/app/#event-gpu-process-crashed
+* https://github.com/electron/devtron
+* https://electron.atom.io/docs/api/app/#event-gpu-process-crashed
 
-Perf:
+Performance:
 
-+ https://github.com/electron/asar
-+ https://github.com/pixijs/pixi.js/issues/2233
-+ https://github.com/pixijs/pixi.js/pull/2481/files
+* https://github.com/electron/asar
+* https://github.com/pixijs/pixi.js/issues/2233
+* https://github.com/pixijs/pixi.js/pull/2481/files
 
 ## Nomenclature
 
-- request (or caller) to renderer (`evt: ${component.name}` sendToRenderer)
-- renderer to converter (`evt: ${uid}` sendToMain)
-- converter to request (or caller, reply)
+* request (or caller) to renderer (`evt: ${component.name}` `sendToRenderer`)
+* renderer to converter (`evt: ${uid}` `sendToMain`)
+* converter to request (or caller, reply)
 
 ```js
 comp.inject = function (opts) { }
 
 comp[/* parse, render, convert */] = function (info, opts, cb) { }
+```
+with
 
-// with
+```js
 opts // => component options container
 cb = (errorCode, result) => {}
 ```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ### Dependencies
 
-The environment you're installing this into may require Poppler.
+The environment you're installing this into may require Poppler for EPS exports.
 
 #### Poppler Installation via Aptitude (used by some \*nix/BSD, e.g. Ubuntu)
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The environment you're installing this into may require Poppler.
 
 ## In Brief
 
-This image exporter is not a completely new tool. Rather, it is comprised of much preexisting functionality which has been organized and isolated into a single canonical repository. Streambed, plotly.js and eventually the R, Python and Julia libraries will require it and optionally configure it for their needs.
+This image exporter is not a completely new tool. Rather, it is comprised of much preexisting functionality which has been organized and isolated into a single canonical repository. Plotly Cloud, plotly.js and eventually the R, Python and Julia libraries will require it and optionally configure it for their needs.
 
 This Image Exporter suite consists broadly of two commandline tools:
 * The "image server," which renders graphs as specified by commandline arguments
@@ -26,8 +26,6 @@ The image runner makes the suite easier to use for plotly.js testing and the R, 
 
 ### Electron
 
-It's way better than `nw.js`, a lot of people are using it. Using it for this project is a no-brainier.
-
 Electron apps juggle between a node.js process (called the **main** process) and browser scripts (call the **renderer** process). Compared to `nw.js`, creating Electron apps requires a little more boiler plate, but Electron makes it much easier to know what globals you have available.
 
 Electron creates an executable environment. That is, `require('electron')` does not do the same when executed as `node index.js` and `electron index.js`. So, to write good unit tests, it becomes important to split logic that only runs in Electron from other things that can be run in Node.js. That's why in `src/app/*`, only `index.js` requires Electron modules. The other modules are _pure_ Node.js and are tested in `test/unit/` using [TAP](http://www.node-tap.org/). The Electron logic is itself tested using [Spectron](https://github.com/electron/spectron) which is much slower.
@@ -36,7 +34,7 @@ Electron creates an executable environment. That is, `require('electron')` does 
 
 This project has a larger scope than the current image server.
 
-We want to export not just Plotly `"data"/"layout"`, but dashboard, print and thumbnail views.  Eventually, we could even export Plotly animations to gifs. Moreover, we probably want some export types to be open-source while others Streambed-only. Therefore, this package defines a _component_ framework. See `src/component/` for two examples.
+We want to export not just Plotly `"data"/"layout"`, but dashboard, print and thumbnail views.  Eventually, we could even export Plotly animations to gifs. Moreover, we probably want some export types to be open-source while others Plotly Cloud-only. Therefore, this package defines a _component_ framework. See `src/component/` for two examples.
 
 Each component has an `inject`, a `parse`, a `render` and a `convert` method:
 * `inject` (optional, main process) returns a string or an array of strings which is injected in the head of the app's HTML index file (e.g `<script src="plotly.js"></script>`)
@@ -48,7 +46,7 @@ Component modules are _just_ plain objects, listing methods. Components aren't i
 
 ### Logging
 
-I propose that this package won't assume anything logging-related. Logging will be achieved by listening to `app` events and piping their info into a user-chosen logger package (e.g. `bunyan` for the Streambed image server).
+Logging can be achieved by listening to `app` events and piping their info into a user-chosen logger package (e.g. `bunyan` for the Plotly Cloud image server).
 
 ## API
 
@@ -78,7 +76,7 @@ app.on('export-error', () => {})
 app.on('renderer-error', () => {})
 ```
 
-and launch it with `electron main.js`.
+…which can be launched by `electron main.js`.
 
 ### `serve`
 
@@ -121,7 +119,7 @@ app.on('export-error', () => {})
 app.on('renderer-error', () => {})
 ```
 
-and launch it with `electron main.js`.
+…which can be launched with `electron main.js`.
 
 ## CLI
 
@@ -135,13 +133,28 @@ A specialized "runner" for Plotly graphs:
 plotly-graph-exporter 20.json https://plot.ly/~empet/14324.json --format svg
 ```
 
-where `20.json` is a local `"data"/"layout"` JSON file and `https://plot.ly/~empet/14324` is a JSON URL.
+…where `20.json` is a local `"data"/"layout"` JSON file and `https://plot.ly/~empet/14324` is the URL of a remote JSON resource.
 
-I'm thinking the R, Python and Julia libraries could simply call `plotly-graph-exporter` to offer offline image generation to their users.
+#### Python Usage Example
+
+```python
+from subprocess import call
+import json
+
+fig = {"data": [{"y": [1,2,1]}]}
+call(['plotly-graph-exporter', json.dumps(fig)])
+```
+
+#### R Usage Example
+
+```R
+library(plotly)
+system2("plotly-graph-exporter", plotly_json(fig, FALSE))
+```
 
 ### Export Server
 
-The Export Server very similar to the current image server but with support for multiple components:
+The Export Server is very similar to the current image server but with support for multiple components:
 
 `plotly-image-server --port 9090`
 
@@ -155,7 +168,7 @@ Dispatch to one component based on the URL of the request:
 
 ### Pixel Comparisons
 
-Similar to the current plotly.js pixel comparison runner, but as a standalone version that our R, Python, Julia libraries could use too for testing purposes.
+This is similar to the current plotly.js pixel comparison runner, but as a standalone version that our R, Python, and Julia libraries could also use for testing purposes.
 
 ## Other Useful Links
 
@@ -172,17 +185,15 @@ Performance:
 
 ## Nomenclature
 
-* request (or caller) to renderer (`evt: ${component.name}` `sendToRenderer`)
-* renderer to converter (`evt: ${uid}` `sendToMain`)
-* converter to request (or caller, reply)
-
+* Request (or caller) to renderer (`evt: ${component.name}` `sendToRenderer`)
+* Renderer to converter (`evt: ${uid}` `sendToMain`)
+* Converter to request (or caller, reply)
 ```js
 comp.inject = function (opts) { }
 
 comp[/* parse, render, convert */] = function (info, opts, cb) { }
 ```
-with
-
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;…with:
 ```js
 opts // => component options container
 cb = (errorCode, result) => {}


### PR DESCRIPTION
My take on @JamesCropcho's https://github.com/plotly/image-exporter/pull/67. I had some spare time today and I thought of given this a shot. I hope @JamesCropcho won't mind.

I started in https://github.com/plotly/image-exporter/commit/d83e524a207ceae7a65b68c4d9bca260f77e41bc with :hocho: obsolete sections as discussed in https://github.com/plotly/image-exporter/pull/67#issuecomment-381189193 then I added a contributing file mostly by moving and improving sections from the current README and finally I rewrote most of what was left in the README taking inspiration from the plotly.js and falcon repos.